### PR TITLE
Display the number of alien bases destroyed and X-Com bases lost in statistics

### DIFF
--- a/bin/standard/xcom1/Language/en-GB.yml
+++ b/bin/standard/xcom1/Language/en-GB.yml
@@ -1076,6 +1076,8 @@ en-GB:
   STR_SOLDIERS_LOST: "Soldiers lost"
   STR_TOTAL_UFOS: "UFOs detected"
   STR_TOTAL_ALIEN_BASES: "Alien bases discovered"
+  STR_ALIEN_BASES_DESTROYED: "Alien bases destroyed"
+  STR_BASES_LOST: "Bases lost"
   STR_PSIONIC_STRENGTH_ABBREVIATION: "PST"
   STR_PSIONIC_SKILL_ABBREVIATION: "PSK"
   FEMALE_CIVILIAN: "Civilian, Female"

--- a/bin/standard/xcom1/Language/en-US.yml
+++ b/bin/standard/xcom1/Language/en-US.yml
@@ -1076,6 +1076,8 @@ en-US:
   STR_SOLDIERS_LOST: "Soldiers lost"
   STR_TOTAL_UFOS: "UFOs detected"
   STR_TOTAL_ALIEN_BASES: "Alien bases discovered"
+  STR_ALIEN_BASES_DESTROYED: "Alien bases destroyed"
+  STR_BASES_LOST: "Bases lost"
   STR_PSIONIC_STRENGTH_ABBREVIATION: "PST"
   STR_PSIONIC_SKILL_ABBREVIATION: "PSK"
   FEMALE_CIVILIAN: "Civilian, Female"

--- a/bin/standard/xcom2/Language/en-GB.yml
+++ b/bin/standard/xcom2/Language/en-GB.yml
@@ -1212,6 +1212,8 @@ en-GB:
   STR_SOLDIERS_LOST: "Aquanauts lost"
   STR_TOTAL_UFOS: "Flying subs detected"
   STR_TOTAL_ALIEN_BASES: "Alien colonies discovered"
+  STR_ALIEN_BASES_DESTROYED: "Alien colonies destroyed"
+  STR_BASES_LOST: "Bases lost"
   STR_PSIONIC_STRENGTH_ABBREVIATION: "MST"
   STR_PSIONIC_SKILL_ABBREVIATION: "MSK"
   FEMALE_CIVILIAN: "Civilian, Female"

--- a/bin/standard/xcom2/Language/en-US.yml
+++ b/bin/standard/xcom2/Language/en-US.yml
@@ -1212,6 +1212,8 @@ en-US:
   STR_SOLDIERS_LOST: "Aquanauts lost"
   STR_TOTAL_UFOS: "Flying subs detected"
   STR_TOTAL_ALIEN_BASES: "Alien colonies discovered"
+  STR_ALIEN_BASES_DESTROYED: "Alien colonies destroyed"
+  STR_BASES_LOST: "Bases lost"
   STR_PSIONIC_STRENGTH_ABBREVIATION: "MST"
   STR_PSIONIC_SKILL_ABBREVIATION: "MSK"
   FEMALE_CIVILIAN: "Civilian, Female"

--- a/src/Menu/StatisticsState.cpp
+++ b/src/Menu/StatisticsState.cpp
@@ -298,9 +298,11 @@ void StatisticsState::listStats()
 	_lstStats->addRow(2, tr("STR_TOTAL_DAYS_WOUNDED").c_str(), Text::formatNumber(daysWounded).c_str());
 	_lstStats->addRow(2, tr("STR_TOTAL_UFOS").c_str(), Text::formatNumber(ufosDetected).c_str());
 	_lstStats->addRow(2, tr("STR_TOTAL_ALIEN_BASES").c_str(), Text::formatNumber(alienBases).c_str());
+	_lstStats->addRow(2, tr("STR_ALIEN_BASES_DESTROYED").c_str(), Text::formatNumber(alienBasesDestroyed).c_str());
 	_lstStats->addRow(2, tr("STR_COUNTRIES_LOST").c_str(), Text::formatNumber(countriesLost).c_str());
 	_lstStats->addRow(2, tr("STR_TOTAL_TERROR_SITES").c_str(), Text::formatNumber(terrorSites).c_str());
 	_lstStats->addRow(2, tr("STR_TOTAL_BASES").c_str(), Text::formatNumber(xcomBases).c_str());
+	_lstStats->addRow(2, tr("STR_BASES_LOST").c_str(), Text::formatNumber(xcomBasesLost).c_str());
 	_lstStats->addRow(2, tr("STR_TOTAL_CRAFT").c_str(), Text::formatNumber(totalCrafts).c_str());
 	_lstStats->addRow(2, tr("STR_TOTAL_SCIENTISTS").c_str(), Text::formatNumber(currentScientists).c_str());
 	_lstStats->addRow(2, tr("STR_TOTAL_ENGINEERS").c_str(), Text::formatNumber(currentEngineers).c_str());


### PR DESCRIPTION
The number of alien bases destroyed and the number of X-Com bases lost are calculated in StatisticsState.cpp but not displayed in the statistics window. This PR makes these numbers display in the statistics window as they were probably intended to.