### PR TITLE
Look for dladdr in dl lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,7 @@ AM_CONDITIONAL([WITH_OPENXCOM_MAN], [test "x$build_man" != "xno"])
 # ==================
 # Check dependencies
 # ==================
+AC_SEARCH_LIBS([dladdr], [dl], [], [ AC_MSG_ERROR([unable to find dladdr()]) ])
 PKG_CHECK_MODULES([SDL],[sdl >= 1.2.13 SDL_mixer >= 1.2.11 SDL_gfx >= 2.0.22 SDL_image >= 1.2])
 PKG_CHECK_MODULES([YAML],[yaml-cpp >= 0.5.3])
 AX_CHECK_GL


### PR DESCRIPTION
Having upgraded my system to Fedora 30, openxcom no longer builds because libdl.so (needed for dladdr, called in src/Engine/CrossPlatform.cpp) no longer gets pulled in by other libraries.  This patch will have configure check if it needs -ldl and include it if needed.