### PR TITLE
Update resorce load

### DIFF
--- a/bin/standard/xcom1/extraSprites.rul
+++ b/bin/standard/xcom1/extraSprites.rul
@@ -56,12 +56,12 @@ extraSprites:
     subX: 32
     subY: 48
     files:
-      -4: Resources/Weapons/Terror.png
+      58: Resources/Weapons/Terror.png
   - type: BIGOBS.PCK
     width: 32
     height: 48
     files:
-      -5: Resources/Weapons/Zombie.png
+      57: Resources/Weapons/Zombie.png
   - type: GlobeMarkers
     width: 27
     height: 3

--- a/bin/standard/xcom1/items.rul
+++ b/bin/standard/xcom1/items.rul
@@ -1208,7 +1208,7 @@ items:
     costSell: 115000
   - type: CYBERDISC_WEAPON
     weight: 3
-    bigSprite: -2
+    bigSprite: 60
     floorSprite: 31
     handSprite: 104
     bulletSprite: 8
@@ -1229,7 +1229,7 @@ items:
     recover: false
   - type: REAPER_WEAPON
     weight: 3
-    bigSprite: -3
+    bigSprite: 59
     floorSprite: 31
     handSprite: 104
     meleeSound: 48
@@ -1246,7 +1246,7 @@ items:
     flatRate: true
   - type: CHRYSSALID_WEAPON
     weight: 3
-    bigSprite: -1
+    bigSprite: 61
     floorSprite: 31
     handSprite: 104
     meleeSound: 49
@@ -1264,7 +1264,7 @@ items:
     flatRate: true
   - type: CELATID_WEAPON
     weight: 3
-    bigSprite: -2
+    bigSprite: 60
     floorSprite: 31
     handSprite: 104
     bulletSprite: 8
@@ -1286,7 +1286,7 @@ items:
     arcingShot: true
   - type: SILACOID_WEAPON
     weight: 3
-    bigSprite: -4
+    bigSprite: 58
     floorSprite: 31
     handSprite: 104
     meleeSound: 50
@@ -1303,7 +1303,7 @@ items:
     flatRate: true
   - type: SECTOPOD_WEAPON
     weight: 3
-    bigSprite: -2
+    bigSprite: 60
     floorSprite: 31
     handSprite: 104
     fireSound: 18
@@ -1326,7 +1326,7 @@ items:
     recover: false
   - type: ZOMBIE_WEAPON
     weight: 3
-    bigSprite: -5
+    bigSprite: 57
     meleeSound: 48
     strengthApplied: true
     damageType: 7

--- a/bin/standard/xcom2/extraSprites.rul
+++ b/bin/standard/xcom2/extraSprites.rul
@@ -57,7 +57,7 @@ extraSprites: #done
     subX: 32
     subY: 48
     files:
-      -9: Resources/Weapons/Terror.png
+      63: Resources/Weapons/Terror.png
   - type: TDXCOM_2.PCK
     files:
       233: Resources/Sprite/missing_arm.png

--- a/bin/standard/xcom2/items.rul
+++ b/bin/standard/xcom2/items.rul
@@ -1414,7 +1414,7 @@ items: #done
     size: 0.8
     costSell: 115000
   - type: STR_BIODRONE_MELEE_WEAPON
-    bigSprite: -2
+    bigSprite: 70
     meleeSound: 26
     strengthApplied: true
     damageType: 7
@@ -1427,7 +1427,7 @@ items: #done
     clipSize: -1
     recover: false
   - type: HALLUCINOID_WEAPON
-    bigSprite: -7
+    bigSprite: 65
     meleeSound: 26
     strengthApplied: true
     damageType: 7
@@ -1440,7 +1440,7 @@ items: #done
     clipSize: -1
     recover: false
   - type: STR_LOBSTERMAN_MELEE_WEAPON
-    bigSprite: -5
+    bigSprite: 67
     meleeSound: 42
     strengthApplied: true
     damageType: 7
@@ -1453,7 +1453,7 @@ items: #done
     clipSize: -1
     recover: false
   - type: CALCINITE_WEAPON
-    bigSprite: -9
+    bigSprite: 63
     meleeSound: 16
     strengthApplied: true
     damageType: 7
@@ -1466,7 +1466,7 @@ items: #done
     clipSize: -1
     recover: false
   - type: DEEP_ONE_WEAPON
-    bigSprite: -3
+    bigSprite: 69
     bulletSprite: 8
     fireSound: 40
     hitSound: 41
@@ -1487,7 +1487,7 @@ items: #done
     arcingShot: true
     hitAnimation: -1
   - type: STR_TRISCENE_MELEE_WEAPON
-    bigSprite: -6
+    bigSprite: 66
     handSprite: 41
     meleeSound: 44
     strengthApplied: true
@@ -1502,7 +1502,7 @@ items: #done
     recover: false
   - type: STR_TRIBIO_SONIC_WEAPON
     weight: 3
-    bigSprite: -8
+    bigSprite: 64
     floorSprite: 29
     handSprite: 40
     fireSound: 36
@@ -1525,7 +1525,7 @@ items: #done
     vaporDensity: 30
   - type: XARQUID_WEAPON
     weight: 3
-    bigSprite: -8
+    bigSprite: 64
     floorSprite: 29
     handSprite: 40
     fireSound: 37
@@ -1547,7 +1547,7 @@ items: #done
     vaporColor: 3
     vaporDensity: 30
   - type: TENTACULAT_WEAPON
-    bigSprite: -4
+    bigSprite: 68
     meleeSound: 42
     strengthApplied: true
     damageType: 7
@@ -1561,7 +1561,7 @@ items: #done
     recover: false
     zombieUnit: STR_ZOMBIE
   - type: ZOMBIE_WEAPON
-    bigSprite: -1
+    bigSprite: 71
     meleeSound: 42
     strengthApplied: true
     damageType: 7

--- a/bin/standard/xcom2/metadata.yml
+++ b/bin/standard/xcom2/metadata.yml
@@ -8,5 +8,6 @@ author: Microprose
 id: xcom2
 
 isMaster: true
+resourceConfig: vars.rul
 loadResources:
   - TFTD

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -737,7 +737,7 @@ void BattlescapeGenerator::deployXCOM()
 			{
 				// only put items in the battlescape that make sense (when the item got a sprite, it's probably ok)
 				RuleItem *rule = _game->getMod()->getItem(i->first, true);
-				if (rule->getBigSprite() > -1 && rule->getBattleType() != BT_NONE && rule->getBattleType() != BT_CORPSE && !rule->isFixed() && _game->getSavedGame()->isResearched(rule->getRequirements()))
+				if (rule->canBeEquippedBeforeBaseDefense() && rule->getBigSprite() > -1 && rule->getBattleType() != BT_NONE && rule->getBattleType() != BT_CORPSE && !rule->isFixed() && _game->getSavedGame()->isResearched(rule->getRequirements()))
 				{
 					for (int count = 0; count < i->second; count++)
 					{

--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -1041,6 +1041,8 @@ void stackTrace(void *ctx)
 #else
 	Log(LOG_FATAL) << "Unfortunately, no stack trace information is available";
 #endif
+#elif __CYGWIN__
+	Log(LOG_FATAL) << "Unfortunately, no stack trace information is available";
 #else
 	void *frames[32];
 	char buf[1024];

--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -470,8 +470,9 @@ std::vector<std::string> getFolderContents(const std::string &path, const std::s
 	{
 		std::string file = dirp->d_name;
 
-		if (file == "." || file == "..")
+		if (file.length() >= 1 && file[0] == '.')
 		{
+			//skip ".", "..", ".git", ".svn", ".bashrc", ".ssh" etc.
 			continue;
 		}
 		if (!compareExt(file, ext))

--- a/src/Engine/ModInfo.cpp
+++ b/src/Engine/ModInfo.cpp
@@ -83,10 +83,6 @@ bool               ModInfo::isMaster()       const { return _isMaster; }
 const std::string &ModInfo::getRequiredExtendedVersion() const { return _requiredExtendedVersion; }
 std::string        ModInfo::getResourceConfigFile() const { return _path + "/" + _resourceConfigFile; }
 int                ModInfo::getReservedSpace()        const { return _reservedSpace;     }
-void ModInfo::setReservedSpace(int reservedSpace)
-{
-	_reservedSpace = reservedSpace;
-}
 
 /**
  * Checks if a given mod can be activated.

--- a/src/Engine/ModInfo.cpp
+++ b/src/Engine/ModInfo.cpp
@@ -61,6 +61,8 @@ void ModInfo::load(const std::string &filename)
 		_master = "";
 		// only masters can load external resource dirs
 		_externalResourceDirs = doc["loadResources"].as< std::vector<std::string> >(_externalResourceDirs);
+		// or basic resource definition
+		_resourceConfigFile = doc["resourceConfig"].as<std::string>(_resourceConfigFile);
 	}
 
 	_master = doc["master"].as<std::string>(_master);
@@ -79,6 +81,7 @@ const std::string &ModInfo::getId()          const { return _id;       }
 const std::string &ModInfo::getMaster()      const { return _master;   }
 bool               ModInfo::isMaster()       const { return _isMaster; }
 const std::string &ModInfo::getRequiredExtendedVersion() const { return _requiredExtendedVersion; }
+std::string        ModInfo::getResourceConfigFile() const { return _path + "/" + _resourceConfigFile; }
 int                ModInfo::getReservedSpace()        const { return _reservedSpace;     }
 void ModInfo::setReservedSpace(int reservedSpace)
 {

--- a/src/Engine/ModInfo.h
+++ b/src/Engine/ModInfo.h
@@ -34,6 +34,7 @@ private:
 	bool _isMaster;
 	int _reservedSpace;
 	std::string _requiredExtendedVersion;
+	std::string _resourceConfigFile;
 	std::vector<std::string> _externalResourceDirs;
 public:
 	/// Creates default metadata for a mod at the specified path.
@@ -65,6 +66,8 @@ public:
 	void setReservedSpace(int reservedSpace);
 	/// Gets the OXCE version required by this mod.
 	const std::string &getRequiredExtendedVersion() const;
+	/// Gets ruleset file where are defined based resosruces like required original game data.
+	std::string getResourceConfigFile() const;
 	/// Gets the list of external resource dirs to load for this mod.
 	const std::vector<std::string> &getExternalResourceDirs() const;
 };

--- a/src/Engine/ModInfo.h
+++ b/src/Engine/ModInfo.h
@@ -62,8 +62,6 @@ public:
 	bool canActivate(const std::string &curMaster) const;
 	/// Gets size of mod, bigger mod reserve more values in common colections/surfacesets.
 	int getReservedSpace() const;
-	/// Sets mod size (DO NOT use this method outside Options::updateReservedSpace()).
-	void setReservedSpace(int reservedSpace);
 	/// Gets the OXCE version required by this mod.
 	const std::string &getRequiredExtendedVersion() const;
 	/// Gets ruleset file where are defined based resosruces like required original game data.

--- a/src/Engine/ModInfo.h
+++ b/src/Engine/ModInfo.h
@@ -64,7 +64,7 @@ public:
 	int getReservedSpace() const;
 	/// Gets the OXCE version required by this mod.
 	const std::string &getRequiredExtendedVersion() const;
-	/// Gets ruleset file where are defined based resosruces like required original game data.
+	/// Gets ruleset file where are defined based resources like required original game data.
 	std::string getResourceConfigFile() const;
 	/// Gets the list of external resource dirs to load for this mod.
 	const std::vector<std::string> &getExternalResourceDirs() const;

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -660,7 +660,6 @@ void updateMods()
 		_masterMod = activeMaster;
 	}
 
-	updateReservedSpace();
 	mapResources();
 	userSplitMasters();
 }
@@ -712,57 +711,6 @@ static void _loadMod(const ModInfo &modInfo, std::set<std::string> circDepCheck)
 		else
 		{
 			throw Exception(modInfo.getId() + " mod requires " + modInfo.getMaster() + " master");
-		}
-	}
-}
-
-void updateReservedSpace()
-{
-	Log(LOG_VERBOSE) << "Updating reservedSpace for master mods if necessary...";
-
-	Log(LOG_VERBOSE) << "_masterMod = " << _masterMod;
-
-	int maxSize = 1;
-	for (std::vector< std::pair<std::string, bool> >::reverse_iterator i = mods.rbegin(); i != mods.rend(); ++i)
-	{
-		if (!i->second)
-		{
-			Log(LOG_VERBOSE) << "skipping inactive mod: " << i->first;
-			continue;
-		}
-
-		const ModInfo &modInfo = _modInfos.find(i->first)->second;
-		if (!modInfo.canActivate(_masterMod))
-		{
-			Log(LOG_VERBOSE) << "skipping mod for non-current master: " << i->first << "(" << modInfo.getMaster() << " != " << _masterMod << ")";
-			continue;
-		}
-
-		if (modInfo.getReservedSpace() > maxSize)
-		{
-			maxSize = modInfo.getReservedSpace();
-		}
-	}
-
-	if (maxSize > 1)
-	{
-		// Small hack: update ALL masters, not only active master!
-		// this is because, there can be a hierarchy of multiple masters (e.g. xcom1 master > fluffyUnicorns master > some fluffyUnicorns mod)
-		// and the one that needs to be updated is actually the "root", i.e. xcom1 master
-		for (std::map<std::string, ModInfo>::iterator i = _modInfos.begin(); i != _modInfos.end(); ++i)
-		{
-			if (i->second.isMaster())
-			{
-				if (i->second.getReservedSpace() < maxSize)
-				{
-					i->second.setReservedSpace(maxSize);
-					Log(LOG_INFO) << "reservedSpace for: " << i->first << " updated to: " << i->second.getReservedSpace();
-				}
-				else
-				{
-					Log(LOG_INFO) << "reservedSpace for: " << i->first << " is: " << i->second.getReservedSpace();
-				}
-			}
 		}
 	}
 }

--- a/src/Engine/Options.h
+++ b/src/Engine/Options.h
@@ -101,8 +101,6 @@ namespace Options
 	void switchDisplay();
 	/// returns the id of the active master mod
 	std::string getActiveMaster();
-	/// Updates the reservedSpace for master mods if necessary
-	void updateReservedSpace();
 	/// Maps resources in active mods to the virtual file system
 	void mapResources();
 	/// Gets the map of mod ids to mod infos

--- a/src/Engine/SoundSet.cpp
+++ b/src/Engine/SoundSet.cpp
@@ -21,13 +21,15 @@
 #include "Sound.h"
 #include "Exception.h"
 #include <sstream>
+#include <climits>
+
 namespace OpenXcom
 {
 
 /**
  * Sets up a new empty sound set.
  */
-SoundSet::SoundSet()
+SoundSet::SoundSet() : _sharedSounds(INT_MAX)
 {
 
 }
@@ -188,6 +190,29 @@ Sound *SoundSet::addSound(unsigned int i)
 {
 	_sounds[i] = new Sound();
 	return _sounds[i];
+}
+
+/**
+ * Set number of shared sound indexs that are accesable for all mods.
+ */
+void SoundSet::setMaxSharedSounds(int i)
+{
+	if (i >= 0)
+	{
+		_sharedSounds = i;
+	}
+	else
+	{
+		_sharedSounds = 0;
+	}
+}
+
+/**
+ * Gets number of shared sound indexs that are accesable for all mods.
+ */
+int SoundSet::getMaxSharedSounds() const
+{
+	return _sharedSounds;
 }
 
 /**

--- a/src/Engine/SoundSet.cpp
+++ b/src/Engine/SoundSet.cpp
@@ -193,7 +193,7 @@ Sound *SoundSet::addSound(unsigned int i)
 }
 
 /**
- * Set number of shared sound indexs that are accesable for all mods.
+ * Set number of shared sound indexs that are accessible for all mods.
  */
 void SoundSet::setMaxSharedSounds(int i)
 {
@@ -208,7 +208,7 @@ void SoundSet::setMaxSharedSounds(int i)
 }
 
 /**
- * Gets number of shared sound indexs that are accesable for all mods.
+ * Gets number of shared sound indexs that are accessible for all mods.
  */
 int SoundSet::getMaxSharedSounds() const
 {

--- a/src/Engine/SoundSet.h
+++ b/src/Engine/SoundSet.h
@@ -35,6 +35,7 @@ class SoundSet
 {
 private:
 	std::map<int, Sound*> _sounds;
+	int _sharedSounds;
 
 	int convertSampleRate(Uint8 *oldsound, unsigned int oldsize, Uint8 *newsound) const;
 public:
@@ -48,6 +49,12 @@ public:
 	Sound *getSound(unsigned int i);
 	/// Creates a new sound and returns a pointer to it.
 	Sound *addSound(unsigned int i);
+
+	/// Set number of shared sound indexs that are accesable for all mods.
+	void setMaxSharedSounds(int i);
+	/// Gets number of shared sound indexs that are accesable for all mods.
+	int getMaxSharedSounds() const;
+
 	/// Gets the total sounds in the set.
 	size_t getTotalSounds() const;
 	/// Loads a specific entry from a CAT file into the soundset.

--- a/src/Engine/SoundSet.h
+++ b/src/Engine/SoundSet.h
@@ -50,9 +50,9 @@ public:
 	/// Creates a new sound and returns a pointer to it.
 	Sound *addSound(unsigned int i);
 
-	/// Set number of shared sound indexs that are accesable for all mods.
+	/// Set number of shared sound indexs that are accessible for all mods.
 	void setMaxSharedSounds(int i);
-	/// Gets number of shared sound indexs that are accesable for all mods.
+	/// Gets number of shared sound indexs that are accessible for all mods.
 	int getMaxSharedSounds() const;
 
 	/// Gets the total sounds in the set.

--- a/src/Engine/SurfaceSet.cpp
+++ b/src/Engine/SurfaceSet.cpp
@@ -18,6 +18,7 @@
  */
 #include "SurfaceSet.h"
 #include <fstream>
+#include <climits>
 #include "Surface.h"
 #include "Exception.h"
 
@@ -29,7 +30,7 @@ namespace OpenXcom
  * @param width Frame width in pixels.
  * @param height Frame height in pixels.
  */
-SurfaceSet::SurfaceSet(int width, int height) : _width(width), _height(height)
+SurfaceSet::SurfaceSet(int width, int height) : _width(width), _height(height), _sharedFrames(INT_MAX)
 {
 
 }
@@ -259,6 +260,29 @@ int SurfaceSet::getWidth() const
 int SurfaceSet::getHeight() const
 {
 	return _height;
+}
+
+/**
+ * Set number of shared frame indexs that are accesable for all mods.
+ */
+void SurfaceSet::setMaxSharedFrames(int i)
+{
+	if (i >= 0)
+	{
+		_sharedFrames = i;
+	}
+	else
+	{
+		_sharedFrames = 0;
+	}
+}
+
+/**
+ * Gets number of shared frame indexs that are accesable for all mods.
+ */
+int SurfaceSet::getMaxSharedFrames() const
+{
+	return _sharedFrames;
 }
 
 /**

--- a/src/Engine/SurfaceSet.cpp
+++ b/src/Engine/SurfaceSet.cpp
@@ -263,7 +263,7 @@ int SurfaceSet::getHeight() const
 }
 
 /**
- * Set number of shared frame indexs that are accesable for all mods.
+ * Set number of shared frame indexs that are accessible for all mods.
  */
 void SurfaceSet::setMaxSharedFrames(int i)
 {
@@ -278,7 +278,7 @@ void SurfaceSet::setMaxSharedFrames(int i)
 }
 
 /**
- * Gets number of shared frame indexs that are accesable for all mods.
+ * Gets number of shared frame indexs that are accessible for all mods.
  */
 int SurfaceSet::getMaxSharedFrames() const
 {

--- a/src/Engine/SurfaceSet.h
+++ b/src/Engine/SurfaceSet.h
@@ -59,9 +59,9 @@ public:
 	/// Gets the height of all frames.
 	int getHeight() const;
 
-	/// Set number of shared frame indexs that are accesable for all mods.
+	/// Set number of shared frame indexs that are accessible for all mods.
 	void setMaxSharedFrames(int i);
-	/// Gets number of shared frame indexs that are accesable for all mods.
+	/// Gets number of shared frame indexs that are accessible for all mods.
 	int getMaxSharedFrames() const;
 
 	/// Gets the total frames in the set.

--- a/src/Engine/SurfaceSet.h
+++ b/src/Engine/SurfaceSet.h
@@ -35,8 +35,10 @@ class Surface;
 class SurfaceSet
 {
 private:
-	int _width, _height;
 	std::map<int, Surface*> _frames;
+	int _width, _height;
+	int _sharedFrames;
+
 public:
 	/// Crates a surface set with frames of the specified size.
 	SurfaceSet(int width, int height);
@@ -56,6 +58,12 @@ public:
 	int getWidth() const;
 	/// Gets the height of all frames.
 	int getHeight() const;
+
+	/// Set number of shared frame indexs that are accesable for all mods.
+	void setMaxSharedFrames(int i);
+	/// Gets number of shared frame indexs that are accesable for all mods.
+	int getMaxSharedFrames() const;
+
 	/// Gets the total frames in the set.
 	size_t getTotalFrames() const;
 	/// Sets the surface set's palette.

--- a/src/Mod/ExtraSounds.cpp
+++ b/src/Mod/ExtraSounds.cpp
@@ -23,6 +23,7 @@
 #include "../Engine/FileMap.h"
 #include "../Engine/Logger.h"
 #include "../Engine/Exception.h"
+#include "Mod.h"
 
 namespace OpenXcom
 {
@@ -30,7 +31,7 @@ namespace OpenXcom
 /**
  * Creates a blank set of extra sound data.
  */
-ExtraSounds::ExtraSounds() : _modIndex(0)
+ExtraSounds::ExtraSounds() : _current(0)
 {
 }
 
@@ -46,11 +47,11 @@ ExtraSounds::~ExtraSounds()
  * @param node YAML node.
  * @param modIndex The internal index of the associated mod.
  */
-void ExtraSounds::load(const YAML::Node &node, int modIndex)
+void ExtraSounds::load(const YAML::Node &node, const ModData* current)
 {
 	_type = node["type"].as<std::string>(_type);
 	_sounds = node["files"].as< std::map<int, std::string> >(_sounds);
-	_modIndex = modIndex;
+	_current = current;
 }
 
 /**
@@ -69,15 +70,6 @@ std::string ExtraSounds::getType() const
 std::map<int, std::string> *ExtraSounds::getSounds()
 {
 	return &_sounds;
-}
-
-/**
- * Gets the mod index for this external sounds set.
- * @return The mod index for this external sounds set.
- */
-int ExtraSounds::getModIndex() const
-{
-	return _modIndex;
 }
 
 /**
@@ -128,16 +120,28 @@ SoundSet *ExtraSounds::loadSoundSet(SoundSet *set) const
 
 void ExtraSounds::loadSound(SoundSet *set, int index, const std::string &fileName) const
 {
+	int indexWithOffset = index;
+	if (indexWithOffset >= set->getMaxSharedSounds())
+	{
+		if ((size_t)indexWithOffset >= _current->Size)
+		{
+			std::ostringstream err;
+			err << "ExtraSounds '" << _type << "' sound '" << indexWithOffset << "' excess mod '"<< _current->Name <<"' size limit " << _current->Size;
+			throw Exception(err.str());
+		}
+		indexWithOffset += _current->Offset;
+	}
+
 	const std::string &fullPath = FileMap::getFilePath(fileName);
-	Sound *sound = set->getSound(index);
+	Sound *sound = set->getSound(indexWithOffset);
 	if (sound)
 	{
-		Log(LOG_VERBOSE) << "Replacing index: " << index;
+		Log(LOG_VERBOSE) << "Replacing sound: " << index << ", using index: " << indexWithOffset;
 	}
 	else
 	{
-		Log(LOG_VERBOSE) << "Adding index: " << index;
-		sound = set->addSound(index + _modIndex);
+		Log(LOG_VERBOSE) << "Adding sound: " << index << ", using index: " << indexWithOffset;
+		sound = set->addSound(indexWithOffset);
 	}
 	sound->load(fullPath);
 }

--- a/src/Mod/ExtraSounds.cpp
+++ b/src/Mod/ExtraSounds.cpp
@@ -123,13 +123,13 @@ void ExtraSounds::loadSound(SoundSet *set, int index, const std::string &fileNam
 	int indexWithOffset = index;
 	if (indexWithOffset >= set->getMaxSharedSounds())
 	{
-		if ((size_t)indexWithOffset >= _current->Size)
+		if ((size_t)indexWithOffset >= _current->size)
 		{
 			std::ostringstream err;
-			err << "ExtraSounds '" << _type << "' sound '" << indexWithOffset << "' exceeds mod '"<< _current->Name <<"' size limit " << _current->Size;
+			err << "ExtraSounds '" << _type << "' sound '" << indexWithOffset << "' exceeds mod '"<< _current->name <<"' size limit " << _current->size;
 			throw Exception(err.str());
 		}
-		indexWithOffset += _current->Offset;
+		indexWithOffset += _current->offset;
 	}
 
 	const std::string &fullPath = FileMap::getFilePath(fileName);

--- a/src/Mod/ExtraSounds.cpp
+++ b/src/Mod/ExtraSounds.cpp
@@ -126,7 +126,7 @@ void ExtraSounds::loadSound(SoundSet *set, int index, const std::string &fileNam
 		if ((size_t)indexWithOffset >= _current->Size)
 		{
 			std::ostringstream err;
-			err << "ExtraSounds '" << _type << "' sound '" << indexWithOffset << "' excess mod '"<< _current->Name <<"' size limit " << _current->Size;
+			err << "ExtraSounds '" << _type << "' sound '" << indexWithOffset << "' exceeds mod '"<< _current->Name <<"' size limit " << _current->Size;
 			throw Exception(err.str());
 		}
 		indexWithOffset += _current->Offset;

--- a/src/Mod/ExtraSounds.h
+++ b/src/Mod/ExtraSounds.h
@@ -25,7 +25,7 @@ namespace OpenXcom
 {
 
 class SoundSet;
-class ModData;
+struct ModData;
 
 /**
  * For adding a set of extra sound data to the game.

--- a/src/Mod/ExtraSounds.h
+++ b/src/Mod/ExtraSounds.h
@@ -25,6 +25,7 @@ namespace OpenXcom
 {
 
 class SoundSet;
+class ModData;
 
 /**
  * For adding a set of extra sound data to the game.
@@ -34,7 +35,7 @@ class ExtraSounds
 private:
 	std::string _type;
 	std::map<int, std::string> _sounds;
-	int _modIndex;
+	const ModData* _current;
 
 	void loadSound(SoundSet *set, int index, const std::string &fileName) const;
 public:
@@ -43,13 +44,11 @@ public:
 	/// Cleans up the external sound set.
 	virtual ~ExtraSounds();
 	/// Loads the data from yaml
-	void load(const YAML::Node &node, int modIndex);
+	void load(const YAML::Node &node, const ModData* current);
 	/// Gets the sound's type.
 	std::string getType() const;
 	/// Gets the list of sounds defined by this mod
 	std::map<int, std::string> *getSounds();
-	/// Gets the mod index for this external sound set.
-	int getModIndex() const;
 	/// Load the external sound into a set.
 	SoundSet *loadSoundSet(SoundSet *set) const;
 };

--- a/src/Mod/ExtraSprites.cpp
+++ b/src/Mod/ExtraSprites.cpp
@@ -247,8 +247,8 @@ SurfaceSet *ExtraSprites::loadSurfaceSet(SurfaceSet *set)
 			}
 			else
 			{
-				Surface *temp = new Surface(_width, _height);
-				temp->loadImage(fullPath);
+				Surface temp = Surface(_width, _height);
+				temp.loadImage(fullPath);
 				int xDivision = _width / _subX;
 				int yDivision = _height / _subY;
 				int frames = xDivision * yDivision;
@@ -259,18 +259,13 @@ SurfaceSet *ExtraSprites::loadSurfaceSet(SurfaceSet *set)
 				{
 					for (int x = 0; x != xDivision; ++x)
 					{
-						Surface *frame = set->getFrame(offset);
-						if (frame)
-						{
-							frame->clear();
-						}
-						frame = getFrame(set, offset, adding);
+						Surface* frame = getFrame(set, offset, adding);
+						frame->clear();
 						// for some reason regular blit() doesn't work here how i want it, so i use this function instead.
-						temp->blitNShade(frame, 0 - (x * _subX), 0 - (y * _subY), 0);
+						temp.blitNShade(frame, 0 - (x * _subX), 0 - (y * _subY), 0);
 						++offset;
 					}
 				}
-				delete temp;
 			}
 		}
 	}

--- a/src/Mod/ExtraSprites.cpp
+++ b/src/Mod/ExtraSprites.cpp
@@ -268,7 +268,7 @@ Surface *ExtraSprites::getFrame(SurfaceSet *set, int index) const
 		if ((size_t)indexWithOffset >= _current->Size)
 		{
 			std::ostringstream err;
-			err << "ExtraSprites '" << _type << "' frame '" << indexWithOffset << "' excess mod '"<< _current->Name <<"' size limit " << _current->Size;
+			err << "ExtraSprites '" << _type << "' frame '" << indexWithOffset << "' exceeds mod '"<< _current->Name <<"' size limit " << _current->Size;
 			throw Exception(err.str());
 		}
 		indexWithOffset += _current->Offset;

--- a/src/Mod/ExtraSprites.cpp
+++ b/src/Mod/ExtraSprites.cpp
@@ -265,13 +265,13 @@ Surface *ExtraSprites::getFrame(SurfaceSet *set, int index) const
 	int indexWithOffset = index;
 	if (indexWithOffset >= set->getMaxSharedFrames())
 	{
-		if ((size_t)indexWithOffset >= _current->Size)
+		if ((size_t)indexWithOffset >= _current->size)
 		{
 			std::ostringstream err;
-			err << "ExtraSprites '" << _type << "' frame '" << indexWithOffset << "' exceeds mod '"<< _current->Name <<"' size limit " << _current->Size;
+			err << "ExtraSprites '" << _type << "' frame '" << indexWithOffset << "' exceeds mod '"<< _current->name <<"' size limit " << _current->size;
 			throw Exception(err.str());
 		}
-		indexWithOffset += _current->Offset;
+		indexWithOffset += _current->offset;
 	}
 
 	Surface *frame = set->getFrame(indexWithOffset);

--- a/src/Mod/ExtraSprites.h
+++ b/src/Mod/ExtraSprites.h
@@ -26,7 +26,7 @@ namespace OpenXcom
 
 class Surface;
 class SurfaceSet;
-class ModData;
+struct ModData;
 
 /**
  * For adding a set of extra sprite data to the game.

--- a/src/Mod/ExtraSprites.h
+++ b/src/Mod/ExtraSprites.h
@@ -26,6 +26,7 @@ namespace OpenXcom
 
 class Surface;
 class SurfaceSet;
+class ModData;
 
 /**
  * For adding a set of extra sprite data to the game.
@@ -35,19 +36,20 @@ class ExtraSprites
 private:
 	std::string _type;
 	std::map<int, std::string> _sprites;
+	const ModData* _current;
 	int _width, _height;
 	bool _singleImage;
-	int _modIndex, _subX, _subY;
+	int _subX, _subY;
 	bool _loaded;
 
-	Surface *getFrame(SurfaceSet *set, int index, bool adding) const;
+	Surface *getFrame(SurfaceSet *set, int index) const;
 public:
 	/// Creates a blank external sprite set.
 	ExtraSprites();
 	/// Cleans up the external sprite set.
 	virtual ~ExtraSprites();
 	/// Loads the data from YAML.
-	void load(const YAML::Node &node, int modIndex);
+	void load(const YAML::Node &node, const ModData* current);
 	/// Gets the sprite's type.
 	std::string getType() const;
 	/// Gets the list of sprites defined by this mod.
@@ -58,8 +60,6 @@ public:
 	int getHeight() const;
 	/// Checks if this is a single surface, or a set of surfaces.
 	bool getSingleImage() const;
-	/// Gets the mod index for this external sprite set.
-	int getModIndex() const;
 	/// Gets the x subdivision.
 	int getSubX() const;
 	/// Gets the y subdivision.

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -725,7 +725,7 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 		if ((size_t)f > curr->Size)
 		{
 			std::ostringstream err;
-			err << "Error for '" << parent << "': offset '" << offset << "' excess mod size limit " << (curr->Size / multipler);
+			err << "Error for '" << parent << "': offset '" << offset << "' exceeds mod size limit " << (curr->Size / multipler);
 			throw Exception(err.str());
 		}
 		if ((size_t)f >= shared)

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -2693,6 +2693,9 @@ namespace
  */
 void Mod::loadVanillaResources()
 {
+	// Create Geoscape surface
+	_sets["GlobeMarkers"] = new SurfaceSet(3, 3);
+
 	// Load palettes
 	const char *pal[] = { "PAL_GEOSCAPE", "PAL_BASESCAPE", "PAL_GRAPHS", "PAL_UFOPAEDIA", "PAL_BATTLEPEDIA" };
 	for (size_t i = 0; i < ARRAYLEN(pal); ++i)

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -763,6 +763,31 @@ void Mod::loadSoundOffset(const std::string &parent, int& sound, const YAML::Nod
 }
 
 /**
+ * Gets the mod offset array for a certain sound.
+ */
+void Mod::loadSoundOffset(const std::string &parent, std::vector<int>& sounds, const YAML::Node &node, const std::string &set) const
+{
+	if (node)
+	{
+		int maxShared = getSoundSet(set)->getMaxSharedSounds();
+		sounds.clear();
+		if (node.IsSequence())
+		{
+			for (YAML::const_iterator i = node.begin(); i != node.end(); ++i)
+			{
+				sounds.push_back(-1);
+				loadOffsetNode(parent, sounds.back(), *i, maxShared, 1);
+			}
+		}
+		else
+		{
+			sounds.push_back(-1);
+			loadOffsetNode(parent, sounds.back(), node, maxShared, 1);
+		}
+	}
+}
+
+/**
  * Returns the appropriate mod-based offset for a generic ID.
  * If the ID is bigger than the max, the mod offset is applied.
  * @param id Numeric ID.

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -661,7 +661,7 @@ const std::vector<std::vector<Uint8> > *Mod::getLUTs() const
  */
 int Mod::getModOffset() const
 {
-	return _modCurrent->Offset;
+	return _modCurrent->offset;
 }
 
 /**
@@ -698,7 +698,7 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 			for (size_t i = 0; i < _modData.size(); ++i)
 			{
 				const ModData& d = _modData[i];
-				if (d.Name == mod)
+				if (d.name == mod)
 				{
 					n = &d;
 					break;
@@ -732,14 +732,14 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 	{
 		int f = offset;
 		f *= multipler;
-		if ((size_t)f > curr->Size)
+		if ((size_t)f > curr->size)
 		{
 			std::ostringstream err;
-			err << "Error for '" << parent << "': offset '" << offset << "' exceeds mod size limit " << (curr->Size / multipler);
+			err << "Error for '" << parent << "': offset '" << offset << "' exceeds mod size limit " << (curr->size / multipler);
 			throw Exception(err.str());
 		}
 		if (f >= shared)
-			f += curr->Offset;
+			f += curr->offset;
 		offset = f;
 	}
 }
@@ -816,7 +816,7 @@ int Mod::getOffset(int id, int max) const
 {
 	assert(_modCurrent);
 	if (id > max)
-		return id + _modCurrent->Offset;
+		return id + _modCurrent->offset;
 	else
 		return id;
 }
@@ -885,10 +885,10 @@ void Mod::loadAll(const std::vector< std::pair< std::string, std::vector<std::st
 		}
 		const ModInfo *modInfo = &Options::getModInfos().at(modId);
 		size_t size = modInfo->getReservedSpace();
-		_modData[i].Name = modId;
-		_modData[i].Offset = 1000 * offset;
-		_modData[i].Info = modInfo;
-		_modData[i].Size = 1000 * size;
+		_modData[i].name = modId;
+		_modData[i].offset = 1000 * offset;
+		_modData[i].info = modInfo;
+		_modData[i].size = 1000 * size;
 		offset += size;
 	}
 
@@ -896,9 +896,9 @@ void Mod::loadAll(const std::vector< std::pair< std::string, std::vector<std::st
 	for (size_t i = 0; _modData.size() > i; ++i)
 	{
 		_modCurrent = &_modData.at(0);
-		if (_modCurrent->Info->isMaster())
+		if (_modCurrent->info->isMaster())
 		{
-			std::string path = _modCurrent->Info->getResourceConfigFile();
+			std::string path = _modCurrent->info->getResourceConfigFile();
 			if (CrossPlatform::fileExists(path))
 			{
 				loadResourceConfigFile(path);

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -126,6 +126,11 @@ std::string Mod::DEBRIEF_MUSIC_GOOD;
 std::string Mod::DEBRIEF_MUSIC_BAD;
 int Mod::DIFFICULTY_COEFFICIENT[5];
 
+/// Predefined name for first loaded mod that have all original data
+const std::string ModNameMaster = "master";
+/// Predefined name for current mod that is loading rulesets.
+const std::string ModNameCurrent = "current";
+
 void Mod::resetGlobalStatics()
 {
 	DOOR_OPEN = 3;
@@ -679,11 +684,11 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 	{
 		offset = node["index"].as<int>();
 		std::string mod = node["mod"].as<std::string>();
-		if (mod == "master")
+		if (mod == ModNameMaster)
 		{
 			curr = &_modData.at(0);
 		}
-		else if (mod == "current")
+		else if (mod == ModNameCurrent)
 		{
 			//nothing
 		}
@@ -865,8 +870,8 @@ void Mod::loadAll(const std::vector< std::pair< std::string, std::vector<std::st
 	_modData.resize(mods.size());
 
 	std::set<std::string> usedModNames;
-	usedModNames.insert("master");
-	usedModNames.insert("current");
+	usedModNames.insert(ModNameMaster);
+	usedModNames.insert(ModNameCurrent);
 
 
 	// calculated offsets and other things for all mods

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -661,6 +661,11 @@ int Mod::getModOffset() const
 
 /**
  * Get offset and index for sound set or sprite set.
+ * @param parent Name of parent node, used for better error message
+ * @param offset Member to load new value.
+ * @param node Node with data
+ * @param shared Max offset limit that is shared for every mod
+ * @param multipler Value used by `projectle` surface set to convert projectle offset to index offset in surface.
  */
 void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, size_t shared, size_t multipler) const
 {
@@ -737,8 +742,11 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 /**
  * Returns the appropriate mod-based offset for a sprite.
  * If the ID is bigger than the surfaceset contents, the mod offset is applied.
- * @param sprite Numeric ID of the sprite.
+ * @param parent Name of parent node, used for better error message
+ * @param sprite Member to load new sprite ID index.
+ * @param node Node with data
  * @param set Name of the surfaceset to lookup.
+ * @param multipler Value used by `projectle` surface set to convert projectle offset to index offset in surface.
  */
 void Mod::loadSpriteOffset(const std::string &parent, int& sprite, const YAML::Node &node, const std::string &set, int multipler) const
 {
@@ -751,7 +759,9 @@ void Mod::loadSpriteOffset(const std::string &parent, int& sprite, const YAML::N
 /**
  * Returns the appropriate mod-based offset for a sound.
  * If the ID is bigger than the soundset contents, the mod offset is applied.
- * @param sound Numeric ID of the sound.
+ * @param parent Name of parent node, used for better error message
+ * @param sound Member to load new sound ID index.
+ * @param node Node with data
  * @param set Name of the soundset to lookup.
  */
 void Mod::loadSoundOffset(const std::string &parent, int& sound, const YAML::Node &node, const std::string &set) const
@@ -764,6 +774,10 @@ void Mod::loadSoundOffset(const std::string &parent, int& sound, const YAML::Nod
 
 /**
  * Gets the mod offset array for a certain sound.
+ * @param parent Name of parent node, used for better error message
+ * @param sounds Member to load new list of sound ID indexes.
+ * @param node Node with data
+ * @param set Name of the soundset to lookup.
  */
 void Mod::loadSoundOffset(const std::string &parent, std::vector<int>& sounds, const YAML::Node &node, const std::string &set) const
 {

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -672,7 +672,7 @@ int Mod::getModOffset() const
  * @param shared Max offset limit that is shared for every mod
  * @param multipler Value used by `projectle` surface set to convert projectle offset to index offset in surface.
  */
-void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, size_t shared, size_t multipler) const
+void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, int shared, size_t multipler) const
 {
 	assert(_modCurrent);
 	const ModData* curr = _modCurrent;
@@ -738,7 +738,7 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 			err << "Error for '" << parent << "': offset '" << offset << "' exceeds mod size limit " << (curr->Size / multipler);
 			throw Exception(err.str());
 		}
-		if ((size_t)f >= shared)
+		if (f >= shared)
 			f += curr->Offset;
 		offset = f;
 	}

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -2908,6 +2908,7 @@ void Mod::loadVanillaResources()
 			"HIT.PCK",
 			"BASEBITS.PCK",
 			"X1.PCK",
+			"INTICON.PCK",
 		};
 
 		for (size_t i = 0; i < ARRAYLEN(surfaceNames); ++i)
@@ -2923,6 +2924,10 @@ void Mod::loadVanillaResources()
 		{
 			SurfaceSet* s = _sets["UnderwaterProjectiles"];
 			s->setMaxSharedFrames(385);
+		}
+		{
+			SurfaceSet* s = _sets["GlobeMarkers"];
+			s->setMaxSharedFrames(8);
 		}
 	}
 	{

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -672,7 +672,7 @@ int Mod::getModOffset() const
  * @param shared Max offset limit that is shared for every mod
  * @param multipler Value used by `projectle` surface set to convert projectle offset to index offset in surface.
  */
-void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, int shared, size_t multipler) const
+void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, int shared, const std::string &set, size_t multipler) const
 {
 	assert(_modCurrent);
 	const ModData* curr = _modCurrent;
@@ -721,7 +721,7 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 	if (offset < -1)
 	{
 		std::ostringstream err;
-		err << "Error for '" << parent << "': offset '" << offset << "' have incorrect value";
+		err << "Error for '" << parent << "': offset '" << offset << "' have incorrect value in set '" << set << "'";
 		throw Exception(err.str());
 	}
 	else if (offset == -1)
@@ -735,7 +735,7 @@ void Mod::loadOffsetNode(const std::string &parent, int& offset, const YAML::Nod
 		if ((size_t)f > curr->size)
 		{
 			std::ostringstream err;
-			err << "Error for '" << parent << "': offset '" << offset << "' exceeds mod size limit " << (curr->size / multipler);
+			err << "Error for '" << parent << "': offset '" << offset << "' exceeds mod size limit " << (curr->size / multipler) << " in set '" << set << "'";
 			throw Exception(err.str());
 		}
 		if (f >= shared)
@@ -757,7 +757,7 @@ void Mod::loadSpriteOffset(const std::string &parent, int& sprite, const YAML::N
 {
 	if (node)
 	{
-		loadOffsetNode(parent, sprite, node, getRule(set, "Sprite Set", _sets, true)->getMaxSharedFrames(), multipler);
+		loadOffsetNode(parent, sprite, node, getRule(set, "Sprite Set", _sets, true)->getMaxSharedFrames(), set, multipler);
 	}
 }
 
@@ -773,7 +773,7 @@ void Mod::loadSoundOffset(const std::string &parent, int& sound, const YAML::Nod
 {
 	if (node)
 	{
-		loadOffsetNode(parent, sound, node, getSoundSet(set)->getMaxSharedSounds(), 1);
+		loadOffsetNode(parent, sound, node, getSoundSet(set)->getMaxSharedSounds(), set, 1);
 	}
 }
 
@@ -795,13 +795,13 @@ void Mod::loadSoundOffset(const std::string &parent, std::vector<int>& sounds, c
 			for (YAML::const_iterator i = node.begin(); i != node.end(); ++i)
 			{
 				sounds.push_back(-1);
-				loadOffsetNode(parent, sounds.back(), *i, maxShared, 1);
+				loadOffsetNode(parent, sounds.back(), *i, maxShared, set, 1);
 			}
 		}
 		else
 		{
 			sounds.push_back(-1);
-			loadOffsetNode(parent, sounds.back(), node, maxShared, 1);
+			loadOffsetNode(parent, sounds.back(), node, maxShared, set, 1);
 		}
 	}
 }

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -268,12 +268,15 @@ public:
 	Sound *getSoundByDepth(unsigned int depth, unsigned int sound, bool error = true) const;
 	/// Gets list of LUT data.
 	const std::vector<std::vector<Uint8> > *getLUTs() const;
+
 	/// Gets the mod offset.
 	int getModOffset() const;
+	/// Get offset and index for sound set or sprite set.
+	void loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, size_t shared, size_t multipler) const;
 	/// Gets the mod offset for a certain sprite.
-	int getSpriteOffset(int sprite, const std::string &set) const;
+	void loadSpriteOffset(const std::string &parent, int& sprite, const YAML::Node &node, const std::string &set, int multipler = 1) const;
 	/// Gets the mod offset for a certain sound.
-	int getSoundOffset(int sound, const std::string &set) const;
+	void loadSoundOffset(const std::string &parent, int& sound, const YAML::Node &node, const std::string &set) const;
 	/// Gets the mod offset for a generic value.
 	int getOffset(int id, int max) const;
 

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -75,10 +75,26 @@ class RuleGlobe;
 class RuleConverter;
 class SoundDefinition;
 class MapScript;
+class ModInfo;
 class RuleVideo;
 class RuleMusic;
 class RuleMissionScript;
 struct StatAdjustment;
+
+/**
+ * Mod data used when loading resources
+ */
+struct ModData
+{
+	/// Mod name
+	std::string Name;
+	/// Optional info about mod
+	const ModInfo* Info;
+	/// Offset that mod use is common sets
+	size_t Offset;
+	/// Maximum size allowed by mod in common sets
+	size_t Size;
+};
 
 /**
  * Contains all the game-specific static data that never changes
@@ -148,10 +164,13 @@ private:
 	std::vector<std::vector<int> > _alienItemLevels;
 	std::vector<SDL_Color> _transparencies;
 	int _facilityListOrder, _craftListOrder, _itemListOrder, _researchListOrder,  _manufactureListOrder, _ufopaediaListOrder, _invListOrder;
-	size_t _modOffset;
+	std::vector<ModData> _modData;
+	ModData* _modCurrent;
 	SDL_Color *_statePalette;
 	std::vector<std::string> _psiRequirements; // it's a cache for psiStrengthEval
 
+	/// Loads a ruleset from a YAML file that have basic resources configuration.
+	void loadResourceConfigFile(const std::string &filename);
 	/// Loads a ruleset from a YAML file.
 	void loadFile(const std::string &filename);
 	/// Loads a ruleset element.
@@ -171,7 +190,7 @@ private:
 	/// Creates a transparency lookup table for a given palette.
 	void createTransparencyLUT(Palette *pal);
 	/// Loads a specified mod content.
-	void loadMod(const std::vector<std::string> &rulesetFiles, size_t modIdx);
+	void loadMod(const std::vector<std::string> &rulesetFiles);
 	/// Loads resources from vanilla.
 	void loadVanillaResources();
 	/// Loads resources from extra rulesets.

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -272,7 +272,7 @@ public:
 	/// Gets the mod offset.
 	int getModOffset() const;
 	/// Get offset and index for sound set or sprite set.
-	void loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, size_t shared, size_t multipler) const;
+	void loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, int shared, size_t multipler) const;
 	/// Gets the mod offset for a certain sprite.
 	void loadSpriteOffset(const std::string &parent, int& sprite, const YAML::Node &node, const std::string &set, int multipler = 1) const;
 	/// Gets the mod offset for a certain sound.

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -87,13 +87,13 @@ struct StatAdjustment;
 struct ModData
 {
 	/// Mod name
-	std::string Name;
+	std::string name;
 	/// Optional info about mod
-	const ModInfo* Info;
+	const ModInfo* info;
 	/// Offset that mod use is common sets
-	size_t Offset;
+	size_t offset;
 	/// Maximum size allowed by mod in common sets
-	size_t Size;
+	size_t size;
 };
 
 /**

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -272,7 +272,7 @@ public:
 	/// Gets the mod offset.
 	int getModOffset() const;
 	/// Get offset and index for sound set or sprite set.
-	void loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, int shared, size_t multipler) const;
+	void loadOffsetNode(const std::string &parent, int& offset, const YAML::Node &node, int shared, const std::string &set, size_t multipler) const;
 	/// Gets the mod offset for a certain sprite.
 	void loadSpriteOffset(const std::string &parent, int& sprite, const YAML::Node &node, const std::string &set, int multipler = 1) const;
 	/// Gets the mod offset for a certain sound.

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -277,6 +277,8 @@ public:
 	void loadSpriteOffset(const std::string &parent, int& sprite, const YAML::Node &node, const std::string &set, int multipler = 1) const;
 	/// Gets the mod offset for a certain sound.
 	void loadSoundOffset(const std::string &parent, int& sound, const YAML::Node &node, const std::string &set) const;
+	/// Gets the mod offset array for a certain sound.
+	void loadSoundOffset(const std::string &parent, std::vector<int>& sounds, const YAML::Node &node, const std::string &set) const;
 	/// Gets the mod offset for a generic value.
 	int getOffset(int id, int max) const;
 

--- a/src/Mod/RuleBaseFacility.cpp
+++ b/src/Mod/RuleBaseFacility.cpp
@@ -48,14 +48,10 @@ void RuleBaseFacility::load(const YAML::Node &node, Mod *mod, int listOrder)
 {
 	_type = node["type"].as<std::string>(_type);
 	_requires = node["requires"].as< std::vector<std::string> >(_requires);
-	if (node["spriteShape"])
-	{
-		_spriteShape = mod->getSpriteOffset(node["spriteShape"].as<int>(_spriteShape), "BASEBITS.PCK");
-	}
-	if (node["spriteFacility"])
-	{
-		_spriteFacility = mod->getSpriteOffset(node["spriteFacility"].as<int>(_spriteFacility), "BASEBITS.PCK");
-	}
+
+	mod->loadSpriteOffset(_type, _spriteShape, node["spriteShape"], "BASEBITS.PCK");
+	mod->loadSpriteOffset(_type, _spriteFacility, node["spriteFacility"], "BASEBITS.PCK");
+
 	_lift = node["lift"].as<bool>(_lift);
 	_hyper = node["hyper"].as<bool>(_hyper);
 	_mind = node["mind"].as<bool>(_mind);
@@ -75,14 +71,10 @@ void RuleBaseFacility::load(const YAML::Node &node, Mod *mod, int listOrder)
 	_radarChance = node["radarChance"].as<int>(_radarChance);
 	_defense = node["defense"].as<int>(_defense);
 	_hitRatio = node["hitRatio"].as<int>(_hitRatio);
-	if (node["fireSound"])
-	{
-		_fireSound = mod->getSoundOffset(node["fireSound"].as<int>(_fireSound), "GEO.CAT");
-	}
-	if (node["hitSound"])
-	{
-		_hitSound = mod->getSoundOffset(node["hitSound"].as<int>(_hitSound), "GEO.CAT");
-	}
+
+	mod->loadSoundOffset(_type, _fireSound, node["fireSound"], "GEO.CAT");
+	mod->loadSoundOffset(_type, _hitSound, node["hitSound"], "GEO.CAT");
+
 	_mapName = node["mapName"].as<std::string>(_mapName);
 	_listOrder = node["listOrder"].as<int>(_listOrder);
 	if (!_listOrder)

--- a/src/Mod/RuleCraft.cpp
+++ b/src/Mod/RuleCraft.cpp
@@ -57,8 +57,8 @@ void RuleCraft::load(const YAML::Node &node, Mod *mod, int listOrder)
 		// used in
 		// Surface set (baseOffset):
 		//   BASEBITS.PCK (33)
-		//   INTICONS.PCK (11)
-		//   INTICONS.PCK (0)
+		//   INTICON.PCK (11)
+		//   INTICON.PCK (0)
 		//
 		// Final index in surfaceset is `baseOffset + sprite + (sprite > 4 ? modOffset : 0)`
 		_sprite = mod->getOffset(node["sprite"].as<int>(_sprite), 4);

--- a/src/Mod/RuleCraft.cpp
+++ b/src/Mod/RuleCraft.cpp
@@ -54,7 +54,13 @@ void RuleCraft::load(const YAML::Node &node, Mod *mod, int listOrder)
 	_requires = node["requires"].as< std::vector<std::string> >(_requires);
 	if (node["sprite"])
 	{
-		// this is an offset in BASEBITS.PCK, and two in INTICONS.PCK
+		// used in
+		// Surface set (baseOffset):
+		//   BASEBITS.PCK (33)
+		//   INTICONS.PCK (11)
+		//   INTICONS.PCK (0)
+		//
+		// Final index in surfaceset is `baseOffset + sprite + (sprite > 4 ? modOffset : 0)`
 		_sprite = mod->getOffset(node["sprite"].as<int>(_sprite), 4);
 	}
 	if (node["marker"])

--- a/src/Mod/RuleCraftWeapon.cpp
+++ b/src/Mod/RuleCraftWeapon.cpp
@@ -47,13 +47,15 @@ void RuleCraftWeapon::load(const YAML::Node &node, Mod *mod)
 	_type = node["type"].as<std::string>(_type);
 	if (node["sprite"])
 	{
-		// this one is an offset within INTICONS.PCK
+		// used in
+		// Surface set (baseOffset):
+		//   BASEBITS.PCK (48)
+		//   INTICONS.PCK (5)
+		//
+		// Final index in surfaceset is `baseOffset + sprite + (sprite > 5 ? modOffset : 0)`
 		_sprite = mod->getOffset(node["sprite"].as<int>(_sprite), 5);
 	}
-	if (node["sound"])
-	{
-		_sound = mod->getSoundOffset(node["sound"].as<int>(_sound), "GEO.CAT");
-	}
+	mod->loadSoundOffset(_type, _sound, node["sound"], "GEO.CAT");
 	_damage = node["damage"].as<int>(_damage);
 	_range = node["range"].as<int>(_range);
 	_accuracy = node["accuracy"].as<int>(_accuracy);

--- a/src/Mod/RuleCraftWeapon.cpp
+++ b/src/Mod/RuleCraftWeapon.cpp
@@ -50,7 +50,7 @@ void RuleCraftWeapon::load(const YAML::Node &node, Mod *mod)
 		// used in
 		// Surface set (baseOffset):
 		//   BASEBITS.PCK (48)
-		//   INTICONS.PCK (5)
+		//   INTICON.PCK (5)
 		//
 		// Final index in surfaceset is `baseOffset + sprite + (sprite > 5 ? modOffset : 0)`
 		_sprite = mod->getOffset(node["sprite"].as<int>(_sprite), 5);

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -32,7 +32,7 @@ namespace OpenXcom
  */
 RuleItem::RuleItem(const std::string &type) : _type(type), _name(type), _size(0.0), _costBuy(0), _costSell(0), _transferTime(24), _weight(3), _bigSprite(-1), _floorSprite(-1), _handSprite(120), _bulletSprite(-1), _fireSound(-1), _hitSound(-1), _hitAnimation(-1), _power(0), _damageType(DT_NONE),
 											_accuracyAuto(0), _accuracySnap(0), _accuracyAimed(0), _tuAuto(0), _tuSnap(0), _tuAimed(0), _clipSize(0), _accuracyMelee(0), _tuMelee(0), _battleType(BT_NONE), _twoHanded(false), _fixedWeapon(false), _waypoints(0), _invWidth(1), _invHeight(1),
-											_painKiller(0), _heal(0), _stimulant(0), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _tuUse(0), _recoveryPoints(0), _armor(20), _turretType(-1), _recover(true), _liveAlien(false), _blastRadius(-1), _attraction(0),
+											_painKiller(0), _heal(0), _stimulant(0), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _tuUse(0), _recoveryPoints(0), _armor(20), _turretType(-1), _recover(true), _ignoreInBaseDefense(false), _liveAlien(false), _blastRadius(-1), _attraction(0),
 											_flatRate(false), _arcingShot(false), _listOrder(0), _maxRange(200), _aimRange(200), _snapRange(15), _autoRange(7), _minRange(0), _dropoff(2), _bulletSpeed(0), _explosionSpeed(0), _autoShots(3), _shotgunPellets(0), _strengthApplied(false), _skillApplied(true),
 											_LOSRequired(false), _underwaterOnly(false), _landOnly(false), _meleeSound(39), _meleePower(0), _meleeAnimation(0), _meleeHitSound(-1), _specialType(-1), _vaporColor(-1), _vaporDensity(0), _vaporProbability(15)
 {
@@ -109,6 +109,7 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder)
 	_armor = node["armor"].as<int>(_armor);
 	_turretType = node["turretType"].as<int>(_turretType);
 	_recover = node["recover"].as<bool>(_recover);
+	_ignoreInBaseDefense = node["ignoreInBaseDefense"].as<bool>(_ignoreInBaseDefense);
 	_liveAlien = node["liveAlien"].as<bool>(_liveAlien);
 	_blastRadius = node["blastRadius"].as<int>(_blastRadius);
 	_attraction = node["attraction"].as<int>(_attraction);
@@ -597,6 +598,16 @@ int RuleItem::getArmor() const
 bool RuleItem::isRecoverable() const
 {
 	return _recover;
+}
+
+
+/**
+* Checks if the item can be equipped in base defense mission.
+* @return True if it can be equipped.
+*/
+bool RuleItem::canBeEquippedBeforeBaseDefense() const
+{
+	return !_ignoreInBaseDefense;
 }
 
 

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -61,47 +61,20 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder)
 	_costSell = node["costSell"].as<int>(_costSell);
 	_transferTime = node["transferTime"].as<int>(_transferTime);
 	_weight = node["weight"].as<int>(_weight);
-	if (node["bigSprite"])
-	{
-		_bigSprite = mod->getSpriteOffset(node["bigSprite"].as<int>(_bigSprite), "BIGOBS.PCK");
-	}
-	if (node["floorSprite"])
-	{
-		_floorSprite = mod->getSpriteOffset(node["floorSprite"].as<int>(_floorSprite), "FLOOROB.PCK");
-	}
-	if (node["handSprite"])
-	{
-		_handSprite = mod->getSpriteOffset(node["handSprite"].as<int>(_handSprite), "HANDOB.PCK");
-	}
-	if (node["bulletSprite"])
-	{
-		// Projectiles: 0-384 entries ((105*33) / (3*3)) (35 sprites per projectile(0-34), 11 projectiles (0-10))
-		_bulletSprite = mod->getOffset(node["bulletSprite"].as<int>(_bulletSprite) * 35, 384);
-	}
-	if (node["fireSound"])
-	{
-		_fireSound = mod->getSoundOffset(node["fireSound"].as<int>(_fireSound), "BATTLE.CAT");
-	}
-	if (node["hitSound"])
-	{
-		_hitSound = mod->getSoundOffset(node["hitSound"].as<int>(_hitSound), "BATTLE.CAT");
-	}
-	if (node["meleeSound"])
-	{
-		_meleeSound = mod->getSoundOffset(node["meleeSound"].as<int>(_meleeSound), "BATTLE.CAT");
-	}
-	if (node["hitAnimation"])
-	{
-		_hitAnimation = mod->getSpriteOffset(node["hitAnimation"].as<int>(_hitAnimation), "SMOKE.PCK");
-	}
-	if (node["meleeAnimation"])
-	{
-		_meleeAnimation = mod->getSpriteOffset(node["meleeAnimation"].as<int>(_meleeAnimation), "HIT.PCK");
-	}
-	if (node["meleeHitSound"])
-	{
-		_meleeHitSound = mod->getSoundOffset(node["meleeHitSound"].as<int>(_meleeHitSound), "BATTLE.CAT");
-	}
+
+	mod->loadSpriteOffset(_type, _bigSprite, node["bigSprite"], "BIGOBS.PCK");
+	mod->loadSpriteOffset(_type, _floorSprite, node["floorSprite"], "FLOOROB.PCK");
+	mod->loadSpriteOffset(_type, _handSprite, node["handSprite"], "HANDOB.PCK");
+	// Projectiles: 0-384 entries ((105*33) / (3*3)) (35 sprites per projectile(0-34), 11 projectiles (0-10))
+	mod->loadSpriteOffset(_type, _bulletSprite, node["bulletSprite"], "Projectiles", 35);
+
+	mod->loadSoundOffset(_type, _fireSound, node["fireSound"], "BATTLE.CAT");
+	mod->loadSoundOffset(_type, _hitSound, node["hitSound"], "BATTLE.CAT");
+	mod->loadSoundOffset(_type, _meleeSound, node["meleeSound"], "BATTLE.CAT");
+	mod->loadSpriteOffset(_type, _hitAnimation, node["hitAnimation"], "SMOKE.PCK");
+	mod->loadSpriteOffset(_type, _meleeAnimation, node["meleeAnimation"], "HIT.PCK");
+	mod->loadSoundOffset(_type, _meleeHitSound, node["meleeHitSound"], "BATTLE.CAT");
+
 	_power = node["power"].as<int>(_power);
 	_compatibleAmmo = node["compatibleAmmo"].as< std::vector<std::string> >(_compatibleAmmo);
 	_damageType = (ItemDamageType)node["damageType"].as<int>(_damageType);

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -60,7 +60,7 @@ private:
 	int _recoveryPoints;
 	int _armor;
 	int _turretType;
-	bool _recover, _liveAlien;
+	bool _recover, _ignoreInBaseDefense, _liveAlien;
 	int _blastRadius, _attraction;
 	bool _flatRate, _arcingShot;
 	int _listOrder, _maxRange, _aimRange, _snapRange, _autoRange, _minRange, _dropoff, _bulletSpeed, _explosionSpeed, _autoShots, _shotgunPellets;
@@ -166,6 +166,8 @@ public:
 	int getArmor() const;
 	/// Gets the item's recoverability.
 	bool isRecoverable() const;
+	/// Checks if the item can be equipped in base defense mission.
+	bool canBeEquippedBeforeBaseDefense() const;
 	/// Gets the item's turret type.
 	int getTurretType() const;
 	/// Checks if this a live alien.

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -69,40 +69,8 @@ void RuleSoldier::load(const YAML::Node &node, Mod *mod)
 	_value = node["value"].as<int>(_value);
 	_transferTime = node["transferTime"].as<int>(_transferTime);
 
-	if (node["deathMale"])
-	{
-		_deathSoundMale.clear();
-		if (node["deathMale"].IsSequence())
-		{
-			for (YAML::const_iterator i = node["deathMale"].begin(); i != node["deathMale"].end(); ++i)
-			{
-				_deathSoundMale.push_back(-1);
-				mod->loadSoundOffset(_type, _deathSoundMale.back(), *i, "BATTLE.CAT");
-			}
-		}
-		else
-		{
-			_deathSoundMale.push_back(-1);
-			mod->loadSoundOffset(_type, _deathSoundMale.back(), node["deathMale"], "BATTLE.CAT");
-		}
-	}
-	if (node["deathFemale"])
-	{
-		_deathSoundFemale.clear();
-		if (node["deathFemale"].IsSequence())
-		{
-			for (YAML::const_iterator i = node["deathFemale"].begin(); i != node["deathFemale"].end(); ++i)
-			{
-				_deathSoundFemale.push_back(-1);
-				mod->loadSoundOffset(_type, _deathSoundFemale.back(), *i, "BATTLE.CAT");
-			}
-		}
-		else
-		{
-			_deathSoundFemale.push_back(-1);
-			mod->loadSoundOffset(_type, _deathSoundFemale.back(), node["deathFemale"], "BATTLE.CAT");
-		}
-	}
+	mod->loadSoundOffset(_type, _deathSoundMale, node["deathMale"], "BATTLE.CAT");
+	mod->loadSoundOffset(_type, _deathSoundFemale, node["deathFemale"], "BATTLE.CAT");
 
 	for (YAML::const_iterator i = node["soldierNames"].begin(); i != node["soldierNames"].end(); ++i)
 	{

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -76,12 +76,14 @@ void RuleSoldier::load(const YAML::Node &node, Mod *mod)
 		{
 			for (YAML::const_iterator i = node["deathMale"].begin(); i != node["deathMale"].end(); ++i)
 			{
-				_deathSoundMale.push_back(mod->getSoundOffset(i->as<int>(), "BATTLE.CAT"));
+				_deathSoundMale.push_back(-1);
+				mod->loadSoundOffset(_type, _deathSoundMale.back(), *i, "BATTLE.CAT");
 			}
 		}
 		else
 		{
-			_deathSoundMale.push_back(mod->getSoundOffset(node["deathMale"].as<int>(), "BATTLE.CAT"));
+			_deathSoundMale.push_back(-1);
+			mod->loadSoundOffset(_type, _deathSoundMale.back(), node["deathMale"], "BATTLE.CAT");
 		}
 	}
 	if (node["deathFemale"])
@@ -91,12 +93,14 @@ void RuleSoldier::load(const YAML::Node &node, Mod *mod)
 		{
 			for (YAML::const_iterator i = node["deathFemale"].begin(); i != node["deathFemale"].end(); ++i)
 			{
-				_deathSoundFemale.push_back(mod->getSoundOffset(i->as<int>(), "BATTLE.CAT"));
+				_deathSoundFemale.push_back(-1);
+				mod->loadSoundOffset(_type, _deathSoundFemale.back(), *i, "BATTLE.CAT");
 			}
 		}
 		else
 		{
-			_deathSoundFemale.push_back(mod->getSoundOffset(node["deathFemale"].as<int>(), "BATTLE.CAT"));
+			_deathSoundFemale.push_back(-1);
+			mod->loadSoundOffset(_type, _deathSoundFemale.back(), node["deathFemale"], "BATTLE.CAT");
 		}
 	}
 

--- a/src/Mod/RuleTerrain.cpp
+++ b/src/Mod/RuleTerrain.cpp
@@ -88,10 +88,7 @@ void RuleTerrain::load(const YAML::Node &node, Mod *mod)
 		_minDepth = node["depth"][0].as<int>(_minDepth);
 		_maxDepth = node["depth"][1].as<int>(_maxDepth);
 	}
-	if (node["ambience"])
-	{
-		_ambience = mod->getSoundOffset(node["ambience"].as<int>(_ambience), "BATTLE.CAT");
-	}
+	mod->loadSoundOffset(_name, _ambience, node["ambience"], "BATTLE.CAT");
 	_ambientVolume = node["ambientVolume"].as<double>(_ambientVolume);
 	_script = node["script"].as<std::string>(_script);
 }

--- a/src/Mod/Unit.cpp
+++ b/src/Mod/Unit.cpp
@@ -73,23 +73,7 @@ void Unit::load(const YAML::Node &node, Mod *mod)
 	{
 		_builtInWeapons.push_back(node["builtInWeapons"].as<std::vector<std::string> >());
 	}
-	if (node["deathSound"])
-	{
-		_deathSound.clear();
-		if (node["deathSound"].IsSequence())
-		{
-			for (YAML::const_iterator i = node["deathSound"].begin(); i != node["deathSound"].end(); ++i)
-			{
-				_deathSound.push_back(-1);
-				mod->loadSoundOffset(_type, _deathSound.back(), *i, "BATTLE.CAT");
-			}
-		}
-		else
-		{
-			_deathSound.push_back(-1);
-			mod->loadSoundOffset(_type, _deathSound.back(), node["deathSound"], "BATTLE.CAT");
-		}
-	}
+	mod->loadSoundOffset(_type, _deathSound, node["deathSound"], "BATTLE.CAT");
 	mod->loadSoundOffset(_type, _aggroSound, node["aggroSound"], "BATTLE.CAT");
 	mod->loadSoundOffset(_type, _moveSound, node["moveSound"], "BATTLE.CAT");
 }

--- a/src/Mod/Unit.cpp
+++ b/src/Mod/Unit.cpp
@@ -80,22 +80,18 @@ void Unit::load(const YAML::Node &node, Mod *mod)
 		{
 			for (YAML::const_iterator i = node["deathSound"].begin(); i != node["deathSound"].end(); ++i)
 			{
-				_deathSound.push_back(mod->getSoundOffset(i->as<int>(), "BATTLE.CAT"));
+				_deathSound.push_back(-1);
+				mod->loadSoundOffset(_type, _deathSound.back(), *i, "BATTLE.CAT");
 			}
 		}
 		else
 		{
-			_deathSound.push_back(mod->getSoundOffset(node["deathSound"].as<int>(), "BATTLE.CAT"));
+			_deathSound.push_back(-1);
+			mod->loadSoundOffset(_type, _deathSound.back(), node["deathSound"], "BATTLE.CAT");
 		}
 	}
-	if (node["aggroSound"])
-	{
-		_aggroSound = mod->getSoundOffset(node["aggroSound"].as<int>(_aggroSound), "BATTLE.CAT");
-	}
-	if (node["moveSound"])
-	{
-		_moveSound = mod->getSoundOffset(node["moveSound"].as<int>(_moveSound), "BATTLE.CAT");
-	}
+	mod->loadSoundOffset(_type, _aggroSound, node["aggroSound"], "BATTLE.CAT");
+	mod->loadSoundOffset(_type, _moveSound, node["moveSound"], "BATTLE.CAT");
 }
 
 /**


### PR DESCRIPTION
Refactor of handing mod sizes and surface indexes.

Breaking change:
* Mods that try access index outside space allocated for this mod will not load.
* Using negative index is illegal now (except `-1` that always mean "empty").