### PR TITLE
Fix zenity error dialog

### DIFF
--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -96,7 +96,7 @@ void getErrorDialog()
 		if (getenv("KDE_SESSION_UID") && system("which kdialog 2>&1 > /dev/null") == 0)
 			errorDlg = "kdialog --error ";
 		else if (system("which zenity 2>&1 > /dev/null") == 0)
-			errorDlg = "zenity --error --text=";
+			errorDlg = "zenity --no-wrap --error --text=";
 		else if (system("which kdialog 2>&1 > /dev/null") == 0)
 			errorDlg = "kdialog --error ";
 		else if (system("which gdialog 2>&1 > /dev/null") == 0)

--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -212,7 +212,9 @@ std::vector<std::string> findDataFolders()
 	// Get global data folders
 	if (char *xdg_data_dirs = getenv("XDG_DATA_DIRS"))
 	{
-		char *dir = strtok(xdg_data_dirs, ":");
+		char xdg_data_dirs_copy[strlen(xdg_data_dirs)+1];
+		strcpy(xdg_data_dirs_copy, xdg_data_dirs);
+		char *dir = strtok(xdg_data_dirs_copy, ":");
 		while (dir != 0)
 		{
 			snprintf(path, MAXPATHLEN, "%s/openxcom/", dir);


### PR DESCRIPTION
On gnome/xfce based linux distributions [1] the error dialog is never shown when openxcom crashes. Instead it outputs a rather cryptic statement to the CLI:
```
(zenity:19512): Gtk-WARNING **: 02:23:42.257: Could not find the icon 'dialog-error-ltr'. The 'hicolor' theme was not found either, perhaps you need to install it.
...
```
Together with the text that is normally shown in the error dialog. This PR should fix that.

As always feedback is welcome

[1] Might be true for other desktop environments as well, haven't tested those though.