### PR TITLE
Fix GCC compile warnings on "GL_GLEXT_VERSION" redefined"

### DIFF
--- a/src/Engine/OpenGL.cpp
+++ b/src/Engine/OpenGL.cpp
@@ -11,6 +11,7 @@
 #ifndef __NO_OPENGL
 
 #include <SDL.h>
+#define __gl_glext_h_
 #include <SDL_opengl.h>
 #include <yaml-cpp/yaml.h>
 #include <fstream>

--- a/src/Engine/OpenGL.h
+++ b/src/Engine/OpenGL.h
@@ -11,6 +11,7 @@
 
 #ifndef __NO_OPENGL
 
+#define __gl_glext_h_
 #include <SDL_opengl.h>
 #include <string>
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -103,6 +103,7 @@
 #include <OpenGL/glext.h>
 #include <GLUT/glut.h>
 #endif
+#define __gl_glext_h_
 #include <SDL_opengl.h>
 #endif
 


### PR DESCRIPTION
On recent Linux distributions [1]_ the `glext.h` copy as provided by SDL gives errors during compilation since it is no longer in sync with the one provided by mesa (which should be the one we want to use).

.. [1] In this case ubuntu but it is likely others will have the same 'problem'.