### PR TITLE
Return to the desktop first before showing an error dialog.

### DIFF
--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -116,6 +116,12 @@ void showError(const std::string &error)
 #ifdef _WIN32
 	MessageBoxA(NULL, error.c_str(), "OpenXcom Error", MB_ICONERROR | MB_OK);
 #else
+	// Drop out of fullscreen first
+	if (Options::fullscreen)
+	{
+	SDL_QuitSubSystem(SDL_INIT_VIDEO);
+	}
+
 	if (errorDlg.empty())
 	{
 		std::cerr << error << std::endl;


### PR DESCRIPTION
Should fix: https://openxcom.org/bugs/openxcom/issues/1464 