### PR TITLE
Save diaries with non-zero monthsService

### DIFF
--- a/src/Savegame/Soldier.cpp
+++ b/src/Savegame/Soldier.cpp
@@ -183,7 +183,7 @@ YAML::Node Soldier::save() const
 	{
 		node["death"] = _death->save();
 	}
-	if (Options::soldierDiaries && (!_diary->getMissionIdList().empty() || !_diary->getSoldierCommendations()->empty()))
+	if (Options::soldierDiaries && (!_diary->getMissionIdList().empty() || !_diary->getSoldierCommendations()->empty() || _diary->getMonthsService() > 0))
 	{
 		node["diary"] = _diary->save();
 	}


### PR DESCRIPTION
Problem
---

Currently, `monthsService` records in soldiers' diaries are unreliable (depend on save-load).

If a soldier doesn't have any missions (or commendations), then `monthsService` continues to increment in memory as the time passes (via `addMonthlyService`), but doesn't get saved to a save.

As a result, on reload every "desk job" soldiers' `monthsService` gets reset until they meet the criteria (e.g. go on a mission). This makes this value inconsistent (can be anything between 0 and the correct number after the first mission), which screws with statistics and commendations.

Proposed solution
---

Make a SoldierDiary that has `monthsService > 0` eligible to be saved in the savegame.

This ensures consistency after save-load with no other impacts that I can see.