### PR TITLE
FLC player now uses standard compliant behavior on default

### DIFF
--- a/src/Engine/FlcPlayer.cpp
+++ b/src/Engine/FlcPlayer.cpp
@@ -350,9 +350,13 @@ void FlcPlayer::decodeVideo(bool skipLastFrame)
 			{
 				delay = _delayOverride > 0 ? _delayOverride : _headerSpeed * (1000.0 / 70.0);
 			}
-			else
+			else if (_useInternalAudio && !_frameCallBack) // this means TFTD videos are playing
 			{
 				delay = _videoDelay;
+			}
+			else
+			{
+				delay = _headerSpeed;
 			}
 
 			waitForNextFrame(delay);


### PR DESCRIPTION
It only reverts back to a work-around for the TFTD video files