### PR TITLE
Fixed: Do not bind keyboard events to unrecognized keys

### DIFF
--- a/src/Engine/InteractiveSurface.cpp
+++ b/src/Engine/InteractiveSurface.cpp
@@ -482,10 +482,15 @@ void InteractiveSurface::onMouseOut(ActionHandler handler)
 /**
  * Sets a function to be called every time a key is pressed when the surface is focused.
  * @param handler Action handler.
- * @param key Keyboard button to check for (note: ignores key modifiers). Set to 0 for any key.
+ * @param key Keyboard button to check for (note: ignores key modifiers). Set to SDLK_ANY for any key.
  */
 void InteractiveSurface::onKeyboardPress(ActionHandler handler, SDLKey key)
 {
+	if (key == SDLK_UNKNOWN)
+	{
+		// Ignore unknown keys
+		return;
+	}
 	if (handler != 0)
 	{
 		_keyPress[key] = handler;
@@ -499,10 +504,15 @@ void InteractiveSurface::onKeyboardPress(ActionHandler handler, SDLKey key)
 /**
  * Sets a function to be called every time a key is released when the surface is focused.
  * @param handler Action handler.
- * @param key Keyboard button to check for (note: ignores key modifiers). Set to 0 for any key.
+ * @param key Keyboard button to check for (note: ignores key modifiers). Set to SDLK_ANY for any key.
  */
 void InteractiveSurface::onKeyboardRelease(ActionHandler handler, SDLKey key)
 {
+	if (key == SDLK_UNKNOWN)
+	{
+		// Ignore unknown keys
+		return;
+	}
 	if (handler != 0)
 	{
 		_keyRelease[key] = handler;


### PR DESCRIPTION
This PR fixes [bug 1481](https://openxcom.org/bugs/openxcom/issues/1481) reported on the old bug tracker.

**Synopsis**: It appears that SDL sometimes cannot recognize special keys and key combinations, depending on the input device. For example, my keyboard (Gigabyte Force K83) has an "Fn" key that can be used in combination with function keys F1-F12 to control volume, media playback etc. Unfortunately, doing this during an OpenXcom session causes it to trigger all unassigned actions from the controls menu. This happens because unassigned actions are actually bound to key code `SDLK_UNKNOWN`, and that's exactly what SDL returns.

This PR fixes the issue by returning early from `InteractiveSurface::onKeyboardPress` and `InteractiveSurface::onKeyboardRelease` if the provided key is SDLK_UNKNOWN. Binding to "any key" is still possible, though I'm not quite sure where it is used. I've also fixed the comments in there that said "set key to 0 for any key", because it's clearly not 0 but `InteractiveSurface::SDLK_ANY` instead (which is -1).