### PR TITLE
Invalidate cache for friendly units between mission stages

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -448,6 +448,7 @@ void BattlescapeGenerator::nextStage()
 			{
 				(*j)->setTurnsSinceSpotted(255);
 				(*j)->getVisibleTiles()->clear();
+				(*j)->setCache(0);
 				if (!selectedFirstSoldier && (*j)->getGeoscapeSoldier())
 				{
 					_save->setSelectedUnit(*j);


### PR DESCRIPTION
This PR fixes [bug 1480](https://openxcom.org/bugs/openxcom/issues/1480) reported on the old bug tracker.

**Synopsis**: When transitioning to the next stage in a multi-part mission, friendly units do not have their cache invalidated. This can lead to visual inconsistencies, and the most glaring one is that units who were floating in the air will still appear to be doing so. This problem can be rectified by forcibly invalidating the cache for all friendly units.

Note that in the current version (without these proposed changes), only the first unit will get its cache invalidated, unless one cycles through units on the inventory screen. This is because the inventory screen resets the selected unit's cache upon initialization. I can definitely confirm this is a caching problem, and the actual state of the unit is being properly reset.