### PR TITLE
Fixed average monthly rating calculation in StatisticsState

### DIFF
--- a/src/Menu/StatisticsState.cpp
+++ b/src/Menu/StatisticsState.cpp
@@ -39,6 +39,7 @@
 #include "../Savegame/SoldierDeath.h"
 #include "../Savegame/BattleUnitStatistics.h"
 #include "../Savegame/Country.h"
+#include "../Savegame/Region.h"
 #include "../Savegame/AlienBase.h"
 
 namespace OpenXcom
@@ -122,7 +123,13 @@ void StatisticsState::listStats()
 	ss << Unicode::TOK_NL_SMALL << time->getDayString(_game->getLanguage()) << " " << tr(time->getMonthString()) << " " << time->getYear();
 	_txtTitle->setText(ss.str());
 
-	int monthlyScore = sumVector(save->getResearchScores()) / (int)save->getResearchScores().size();
+	int totalScore = sumVector(save->getResearchScores());
+	for (std::vector<Region*>::iterator iter = save->getRegions()->begin(); iter != save->getRegions()->end(); ++iter)
+	{
+		totalScore += sumVector((*iter)->getActivityXcom()) - sumVector((*iter)->getActivityAlien());
+	}
+
+	int monthlyScore = totalScore / (int)save->getResearchScores().size();
 	int64_t totalIncome = sumVector(save->getIncomes());
 	int64_t totalExpenses = sumVector(save->getExpenditures());
 


### PR DESCRIPTION
This PR fixes [bug 1409](https://openxcom.org/bugs/openxcom/issues/1409) reported on the old bug tracker.

**Synopsis:** The value for "Average monthly rating" in the end-game statistics window is calculated incorrectly. It is derived only from the research scores vector, disregarding both XCOM and alien activity in regions. The proposed fix is to employ the same calculation as the one used in the geoscape graphs window: research score plus XCOM activity minus alien activity.

Do note that there are at least two other problems with this calculation:

- Only the last 12 months (at most) are used to calculate the average value. This is because the game is programmed to store at most 12 values of statistical data in each vector (I first mentioned this [on the forum](https://openxcom.org/forum/index.php?topic=6511.0) as issue no. 4). This also affects the values for total income and total expenditure. I can report this as a separate issue if necessary.
- The data for the current month is included, but we do not account for the fact that the month is not yet over, and we still consider it a full month rather than a fraction of a month. I haven't changed it because this PR is intended to address only the semantics of the score calculation. If necessary, I can make another change, or a separate PR.