### PR TITLE
Allow player access to the built-in melee attack for Lobstermen

### DIFF
--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -89,6 +89,12 @@ private:
 	void blinkHealthBar();
 	/// Shows the unit kneel state.
 	void toggleKneelButton(BattleUnit* unit);
+	/// Gets the item currently accessible through the left hand slot in the battlescape UI.
+	BattleItem *getLeftHandItem(BattleUnit *unit);
+	/// Gets the item currently accessible through the right hand slot in the battlescape UI.
+	BattleItem *getRightHandItem(BattleUnit *unit);
+	/// Gets the built-in melee weapon of a unit, if any.
+	BattleItem *getSpecialMeleeWeapon(BattleUnit *unit);
 public:
 	/// Selects the next soldier.
 	void selectNextPlayerUnit(bool checkReselect = false, bool setReselect = false, bool checkInventory = false, bool checkFOV = true);


### PR DESCRIPTION
This PR resolves #1252 by allowing access to the built-in melee weapon of a unit from the battlescape UI.

**Synopsis:** See #1252 for details.

**TL;DR:** Lobstemen melee attack cannot be accessed when the unit is under player control. I have attempted to rectify the problem by allowing access to the special melee weapon through either of the two hand slots, provided that at least one of them is unoccupied. If both hand slots are empty, the right hand slot is used by default.

Note that all changes are UI only. Also, the active hand is only changed if the weapon being used is from the inventory, preserving the original behavior.

I have tested this in various scenarios and haven't encountered any unusual behavior so far. But it'd still be best if someone else could review the changes - there may be some special case that I've missed.
