### PR TITLE
Fix edge case for items and live alien recovery after a mission.

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -700,7 +700,7 @@ void DebriefingState::btnOkClick(Action *)
 			{
 				_game->pushState(new CannotReequipState(_missingItems));
 			}
-			else if (_manageContainment)
+			if (_manageContainment)
 			{
 				_game->pushState(new ManageAlienContainmentState(_base, OPT_BATTLESCAPE));
 				_game->pushState(new ErrorMessageState(tr("STR_CONTAINMENT_EXCEEDED").arg(_base->getName()), _palette, _game->getMod()->getInterface("debriefing")->getElement("errorMessage")->color, "BACK01.SCR", _game->getMod()->getInterface("debriefing")->getElement("errorPalette")->color));


### PR DESCRIPTION
Before this commit the game would not force the player to sell/destroy excess items/aliens after a mission under the following conditions:
* Too little items in base storage to restock the craft
* Alien containment has not enough free slots to hold all the captured live aliens
* User activated the option "storageLimitsEnforced"

After this commit the game behaves the same as you would normally see when there is enough to restock the craft.

--- Extra ---
Bug was introduced by c74a3522. 
By moving the `_noContainment` check the else clause for `_manageContainment` accidently became part of the `!_missingItems.empty()` control flow.

Just another testament that we are mere humans and not alien overlords ;)