### PR TITLE
Prevent AI frozen in place

### DIFF
--- a/src/Battlescape/AIModule.cpp
+++ b/src/Battlescape/AIModule.cpp
@@ -79,6 +79,16 @@ AIModule::~AIModule()
 }
 
 /**
+ * Resets the unsaved AI state.
+ */
+void AIModule::reset()
+{
+	// these variables are not saved in save() and also not initiated in think()
+	_escapeTUs = 0;
+	_ambushTUs = 0;
+}
+
+/**
  * Loads the AI state from a YAML file.
  * @param node YAML node.
  */

--- a/src/Battlescape/AIModule.h
+++ b/src/Battlescape/AIModule.h
@@ -58,6 +58,8 @@ public:
 	AIModule(SavedBattleGame *save, BattleUnit *unit, Node *node);
 	/// Cleans up the AIModule.
 	~AIModule();
+	/// Resets the unsaved AI state.
+	void reset();
 	/// Loads the AI Module from YAML.
 	void load(const YAML::Node& node);
 	/// Saves the AI Module to YAML.

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -884,6 +884,10 @@ void SavedBattleGame::endTurn()
 			{
 				(*i)->setTurnsSinceSpotted(0);
 			}
+			if ((*i)->getAIModule())
+			{
+				(*i)->getAIModule()->reset(); // clean up AI state
+			}
 		}
 	}
 	// hide all aliens (VOF calculations below will turn them visible again)


### PR DESCRIPTION
I received a report of AI freeze, which looks like this:
1. AI runs setupEscape() and decides it should escape to the same tile
as it currently occupies (for whatever reason); _escapeTUs is set to 1
2. AI evaluation sets _AIMode to 3 (=escape)
3. at the end of the think() cycle, _escapeTUs is not reset
(because there is no need to move)

Starting from this point setupEscape() is not executed anymore,
because _escapeTUs != 0. And as long as the enemy sees (or knows about)
xcom, it will not re-evaluate. Thus every turn it will just stay where
it is without doing anything (only thing it can do are reaction shots).

The freeze breaks only after turn 20 (or other forced re-evaluate).
Or after save and reload... because _escapeTUs is not saved
and will get reset back to 0 after reload.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->