### PR TITLE
Silence OpenGL deprecation warnings on MacOS 10.14+

### DIFF
--- a/src/Engine/OpenGL.h
+++ b/src/Engine/OpenGL.h
@@ -11,6 +11,10 @@
 
 #ifndef __NO_OPENGL
 
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#endif
+
 #include <SDL_opengl.h>
 #include <string>
 


### PR DESCRIPTION
I tried building on MacOS Catalina (10.15.7) with XCode 12.0 and noticed I get a lot of deprecation warnings for OpenGL e.g.

```
/OpenXcom/src/Engine/OpenGL.cpp:115:3: error: 'glGenTextures' is deprecated: first deprecated in macOS 10.14 - OpenGL
      API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Werror,-Wdeprecated-declarations]
                glGenTextures(1, &gltexture);
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/OpenGL.framework/Headers/gl.h:2498:13: note: 
      'glGenTextures' has been explicitly marked deprecated here
extern void glGenTextures (GLsizei n, GLuint *textures) OPENGL_DEPRECATED(10.0, 10.14);
```
 
These warnings then cause the build to fail (since treat warnings as errors is enabled by default).

This is **not** a proper fix for this issue. It does allow building on MacOS 10.14 and later but a proper fix for this would be to use Apple's Metal API rather than OpenGL which I don't have the time or inclination to learn just yet. In the interim I think this is a reasonable compromise (until Apple remove the deprecated OpenGL API, which knowing Apple will probably happen in 10.16).

