### PR TITLE
Fix for RelWithDebInfo behaving as debug build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -374,8 +374,6 @@ if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES 
       )
     if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
       # add warning flags recognized by g++ but not by clang
-      add_compile_options (
-	  )
     elseif ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
       # add warning flags recognized by clang but not by g++
     endif ()
@@ -390,12 +388,8 @@ if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES 
     )
   if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
     # add warning flags recognized by g++ but not by clang
-    add_compile_options (
-      )
   elseif ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     # add warning flags recognized by clang but not by g++
-    add_compile_options (
-      )
   endif ()
 endif ()
 


### PR DESCRIPTION
The empty "add_compile_options()" seem to clear all other compile flags. Removing them should not hurt.
Should fix #1284 

Image shows CMakeCache.txt diff. Left is before this commit, right is after (and equal to behavior before pr #1280 )
![Screenshot_2020-11-11_18-51-25](https://user-images.githubusercontent.com/13455253/98846580-780bfd00-244f-11eb-8521-ceb7aecc3b15.png)

--edit--
Fix PR description (title and text link to issue)


