### PR TITLE
Fix synopsis section in the manpage

### DIFF
--- a/docs/openxcom.6
+++ b/docs/openxcom.6
@@ -8,7 +8,7 @@
 game
 .Sh SYNOPSIS
 .Nm
-.Op Fl \? | help
+.Op Fl ? | help
 .Op Fl data Ar path
 .Op Fl user Ar path
 .Op Fl cfg Ar path
@@ -63,7 +63,7 @@ for a list of all potential options.
 .El
 .Sh INSTALLATION
 .Nm OpenXcom
-requires a vanilla copy of the X-COM resources -- from either or both of the original games.
+requires a vanilla copy of the X-COM resources \(em from either or both of the original games.
 Please refer to the
 .Pa README.md
 for the default search paths and the exact directory layout, as well as information on the Mod support.


### PR DESCRIPTION
When I viewed the new man page, I got error messages saying `<standard input>:14: missing \?` in the console. Then when I read the man page I noticed something odd in `SYNOPSIS` section:
```
SYNOPSIS
     openxcom [] [-Enemy | -help] [-data path] [-user path] [-cfg path] [-master mod] [-KEY VALUE]
```
The source suggests the intention was to say `openxcom [-? | -help] ...`. Deleting the backslash before the question mark does that.

Also, `mandoc` linter told me that using `--` is deprecated and to use `\(em` instead - so I did that.

Tested in Slackware-14.2, Gentoo and Ubuntu 18.04. Display of synopsis was wrong in all environments I tested in, but only Slackware showed me the error quoted in the first paragraph.
<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->