### PR TITLE
Install the manpage only for Linux/*BSD, run `make install` during CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,10 @@ jobs:
         shell: bash
         run: |
           echo "describe=$(git describe)" >> $GITHUB_ENV
-
+          if [ "${{ matrix.name }}" = "Linux" ]; then
+            echo "MAYBE_SUDO=sudo" >> $GITHUB_ENV
+          fi
+          echo "CMAKE_BUILD_PARALLEL_LEVEL=`getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 2`" >> $GITHUB_ENV
       - name: Download dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -83,7 +86,6 @@ jobs:
 
       - name: Generate project files
         run: |
-          mkdir ${{ matrix.build-dir || 'build' }}
           cmake -B ${{ matrix.build-dir || 'build' }} ${{ matrix.build-src-dir || '.' }} -DCMAKE_BUILD_TYPE=Release -DENABLE_WARNING=1 -DCHECK_CCACHE=1 ${{ matrix.cmake-args }}
         env:
           CC: ${{ matrix.compiler }}
@@ -91,7 +93,16 @@ jobs:
 
       - name: Compile source code
         run: |
-          cmake --build ${{ matrix.build-dir || 'build' }} -v -j2 --config ${{ matrix.build-config || 'Release' }} -- ${{ matrix.build-args }}
+          cmake --build ${{ matrix.build-dir || 'build' }} -v --config ${{ matrix.build-config || 'Release' }} -- ${{ matrix.build-args }}
+
+        # Note, this is bogus on MacOS, as it installs shaders et al twice.
+        # Windows installs under C:/Program Files (x86)/OpenXcom/bin (where the
+        # 'bin' is pretty redundant) and Linux installs under various dirs under
+        # /usr/local
+      - name: Make install
+        shell: bash
+        run: |
+          $MAYBE_SUDO cmake --build ${{ matrix.build-dir || 'build' }} -v --config ${{ matrix.build-config || 'Release' }} --target install
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v2

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -36,4 +36,7 @@ else ()
   message ( "No doxygen command found. Disable API documentation generation" )
 endif ()
 
-INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/openxcom.6 DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man6)
+# Only useful for make install/package under *nix OSes, but not macOS.
+if ( UNIX AND NOT APPLE )
+    INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/openxcom.6 DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man6)
+endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -481,10 +481,6 @@ if ( WIN32 )
     set ( static_flags  -static )
     set ( SDLMIXER_LIBRARY "${SDLMIXER_LIBRARY} -lwinmm" )
   endif ()
-  if ( MSVC )
-    set_target_properties ( openxcom
-      PROPERTIES PREFIX ../ )
-  endif ()
   set ( system_libs ${basic_windows_libs} SDLmain ${static_flags} )
 endif ()
 


### PR DESCRIPTION
Reported by: @MeridianOXC

The manpage is pretty useless under Windows and also for the macOS `dmg`
archives. The `make install` target could also use some more work, but
at least it's working now.

CPack could potentially be used, but would need a lot of work and the
current GH artifact build step is actually superior.

While here, use the proper NPROC value for all runners (except windows,
which falls back to 2). Linux needs sudo to install, Win/Mac don't.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->