### PR TITLE
snap new base to the nearest city in XCOM1

### DIFF
--- a/bin/standard/New_Base_In_City/New_Base_In_City.rul
+++ b/bin/standard/New_Base_In_City/New_Base_In_City.rul
@@ -1,0 +1,3 @@
+# New_Base_In_City
+constants:
+  - newBaseInCity: true

--- a/bin/standard/New_Base_In_City/metadata.yml
+++ b/bin/standard/New_Base_In_City/metadata.yml
@@ -1,0 +1,9 @@
+#
+# metadata.yaml for New Base In City
+
+name: "New Base In City"
+version: 1.0
+description: "Build the new base in the nearest city to the chosen point."
+author: the OpenXcom team
+
+master: xcom1

--- a/src/Geoscape/BuildNewBaseState.cpp
+++ b/src/Geoscape/BuildNewBaseState.cpp
@@ -234,6 +234,10 @@ void BuildNewBaseState::globeClick(Action *action)
 	{
 		if (_globe->insideLand(lon, lat))
 		{
+			if (Mod::NEW_BASE_IN_CITY && Options::getActiveMaster() == "xcom1")
+			{
+				_globe->setToNearestCity(&lon, &lat);
+			}
 			_base->setLongitude(lon);
 			_base->setLatitude(lat);
 			for (std::vector<Craft*>::iterator i = _base->getCrafts()->begin(); i != _base->getCrafts()->end(); ++i)

--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -18,6 +18,7 @@
  */
 #include "Globe.h"
 #include <algorithm>
+#include <cassert>
 #include "../fmath.h"
 #include "../Engine/Action.h"
 #include "../Engine/SurfaceSet.h"
@@ -1906,6 +1907,39 @@ void Globe::setCraftRange(double lon, double lat, double range)
 	_craftLon = lon;
 	_craftLat = lat;
 	_craftRange = range;
+}
+
+/**
+ * Set the longitude and latitude to the nearest city of the same region.
+ * @param lon Pointer to the input and output longitude
+ * @param lat Pointer to the input and output latitude
+ */
+void Globe::setToNearestCity(double *lon, double *lat)
+{
+	assert(lon);
+	assert(lat);
+
+	double bestLon = *lon;
+	double bestLat = *lat;
+	double eigenValue = -1;
+	std::vector<City *> *pCities = _game->getSavedGame()->locateRegion(*lon, *lat)->getRules()->getCities();
+
+	for (std::vector<City *>::const_iterator i = pCities->begin(); i != pCities->end(); ++i)
+	{
+		double cityLon = (*i)->getLongitude();
+		double cityLat = (*i)->getLatitude();
+		double value = sin(*lat) * sin(cityLat) + cos(*lat) * cos(cityLat) * cos((*lon) - cityLon);
+
+		if (value >= eigenValue)
+		{
+			bestLon = cityLon;
+			bestLat = cityLat;
+			eigenValue = value;
+		}
+	}
+
+	*lon = bestLon;
+	*lat = bestLat;
 }
 
 }

--- a/src/Geoscape/Globe.h
+++ b/src/Geoscape/Globe.h
@@ -205,6 +205,8 @@ public:
 	void setNewBaseHover(bool hover);
 	/// Sets craft range mode.
 	void setCraftRange(double lon, double lat, double range);
+	/// Sets the longitude and latitude to the nearest city.
+	void setToNearestCity(double *lon, double *lat);
 	/// set the _radarLines variable
 	void toggleRadarLines();
 	/// Update the resolution settings, we just resized the window.

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -126,6 +126,7 @@ int Mod::EXPLOSIVE_DAMAGE_RANGE;
 int Mod::FIRE_DAMAGE_RANGE[2];
 std::string Mod::DEBRIEF_MUSIC_GOOD;
 std::string Mod::DEBRIEF_MUSIC_BAD;
+bool Mod::NEW_BASE_IN_CITY;
 int Mod::DIFFICULTY_COEFFICIENT[5];
 
 /// Predefined name for first loaded mod that have all original data
@@ -172,6 +173,7 @@ void Mod::resetGlobalStatics()
 	FIRE_DAMAGE_RANGE[1] = 10;
 	DEBRIEF_MUSIC_GOOD = "GMMARS";
 	DEBRIEF_MUSIC_BAD = "GMMARS";
+	NEW_BASE_IN_CITY = false;
 
 	Globe::OCEAN_COLOR = Palette::blockOffset(12);
 	Globe::OCEAN_SHADING = true;
@@ -1134,6 +1136,7 @@ void Mod::loadConstants(const YAML::Node &node)
 	}
 	DEBRIEF_MUSIC_GOOD = node["goodDebriefingMusic"].as<std::string>(DEBRIEF_MUSIC_GOOD);
 	DEBRIEF_MUSIC_BAD = node["badDebriefingMusic"].as<std::string>(DEBRIEF_MUSIC_BAD);
+	NEW_BASE_IN_CITY = node["newBaseInCity"].as<bool>(NEW_BASE_IN_CITY);
 }
 
 /**

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -237,6 +237,7 @@ public:
 	static int FIRE_DAMAGE_RANGE[2];
 	static std::string DEBRIEF_MUSIC_GOOD;
 	static std::string DEBRIEF_MUSIC_BAD;
+	static bool NEW_BASE_IN_CITY;
 	static int DIFFICULTY_COEFFICIENT[5];
 	// reset all the statics in all classes to default values
 	static void resetGlobalStatics();


### PR DESCRIPTION
Paranoids like me always want to have bases built at the very same point of a city in XCOM1.
Unfortunately, the base naming dialog hasn't a cancel button, neither will it respond to ESC button, thus make it somehow cumbersome.
The mobile version makes it more difficult.
I added a new feature to automatically snap new base to the nearest city in XCOM1 when enabled.