### PR TITLE
Set the default cmake build type to Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required ( VERSION 3.1 )
 project ( OpenXcom )
 
 set ( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" )
+include(BuildType)
 include(GNUInstallDirs)
 
 # For yaml-cpp

--- a/cmake/modules/BuildType.cmake
+++ b/cmake/modules/BuildType.cmake
@@ -1,0 +1,15 @@
+# From https://raw.githubusercontent.com/OpenChemistry/tomviz/master/cmake/BuildType.cmake
+# Their project license is BSDL 3-Clause
+# Found via https://blog.kitware.com/cmake-and-the-default-build-type/
+#
+# Set a default build type if none was specified
+set(default_build_type "Release")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "MinSizeRel" "RelWithDebInfo")
+endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -35,8 +35,3 @@ if ( NOT ( DOXYGEN_EXECUTABLE MATCHES "NOTFOUND" ) )
 else ()
   message ( "No doxygen command found. Disable API documentation generation" )
 endif ()
-
-# Only useful for make install/package under *nix OSes, but not macOS.
-if ( UNIX AND NOT APPLE )
-    INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/openxcom.6 DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man6)
-endif ()


### PR DESCRIPTION
This should help with the transition from autotools where that is the
default. It should stop issues like #1284 and #1292 and these can be
considered closed.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->