### PR TITLE
More precise distance calculation for 2x2 units

### DIFF
--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -993,7 +993,8 @@ void Map::drawTerrain(Surface *surface)
 								BattleAction *action = _save->getBattleGame()->getCurrentAction();
 								RuleItem *weapon = action->weapon->getRules();
 								int accuracy = action->actor->getFiringAccuracy(action->type, action->weapon);
-								int distance = _save->getTileEngine()->distance(Position (itX, itY,itZ), action->actor->getPosition());
+								int distanceSq = _save->getTileEngine()->distanceUnitToPositionSq(action->actor, Position (itX, itY,itZ), false);
+								int distance = (int)std::ceil(sqrt(float(distanceSq)));
 								int upperLimit = 200;
 								int lowerLimit = weapon->getMinRange();
 								switch (action->type)
@@ -1027,20 +1028,17 @@ void Map::drawTerrain(Surface *surface)
 									_txtAccuracy->setColor(Palette::blockOffset(Pathfinding::green - 1)-1);
 								}
 
-								bool outOfRange = distance > weapon->getMaxRange();
+								bool outOfRange = distanceSq > weapon->getMaxRangeSq();
 								// special handling for short ranges and diagonals
-								if (outOfRange && action->actor->directionTo(action->target) % 2 == 1)
+								if (outOfRange)
 								{
-									// special handling for maxRange 1: allow it to target diagonally adjacent tiles, even though they are technically 2 tiles away.
-									if (weapon->getMaxRange() == 1
-										&& distance == 2)
+									// special handling for maxRange 1: allow it to target diagonally adjacent tiles (one diagonal move)
+									if (weapon->getMaxRange() == 1 && distanceSq <= 3)
 									{
 										outOfRange = false;
 									}
-									// special handling for maxRange 2: allow it to target diagonally adjacent tiles on a level above/below, even though they are technically 3 tiles away.
-									else if (weapon->getMaxRange() == 2
-										&& distance == 3
-										&& itZ != action->actor->getPosition().z)
+									// special handling for maxRange 2: allow it to target diagonally adjacent tiles (one diagonal move + one straight move)
+									else if (weapon->getMaxRange() == 2 && distanceSq <= 6)
 									{
 										outOfRange = false;
 									}

--- a/src/Battlescape/ProjectileFlyBState.cpp
+++ b/src/Battlescape/ProjectileFlyBState.cpp
@@ -124,7 +124,7 @@ void ProjectileFlyBState::init()
 	}
 
 	Tile *endTile = _parent->getSave()->getTile(_action.target);
-	int distance = _parent->getTileEngine()->distance(_action.actor->getPosition(), _action.target);
+	int distanceSq = _parent->getTileEngine()->distanceUnitToPositionSq(_action.actor, _action.target, false);
 	bool isPlayer = _parent->getSave()->getSide() == FACTION_PLAYER;
 	if (isPlayer) _parent->getMap()->resetObstacles();
 	switch (_action.type)
@@ -145,21 +145,17 @@ void ProjectileFlyBState::init()
 			_parent->popState();
 			return;
 		}
-		if (distance > weapon->getRules()->getMaxRange())
+		if (distanceSq > weapon->getRules()->getMaxRangeSq())
 		{
 			// special handling for short ranges and diagonals
-			if (_action.actor->directionTo(_action.target) % 2 == 1)
 			{
-				// special handling for maxRange 1: allow it to target diagonally adjacent tiles, even though they are technically 2 tiles away.
-				if (weapon->getRules()->getMaxRange() == 1
-					&& distance == 2)
+				// special handling for maxRange 1: allow it to target diagonally adjacent tiles (one diagonal move)
+				if (weapon->getRules()->getMaxRange() == 1 && distanceSq <= 3)
 				{
 					break;
 				}
-				// special handling for maxRange 2: allow it to target diagonally adjacent tiles on a level above/below, even though they are technically 3 tiles away.
-				else if (weapon->getRules()->getMaxRange() == 2
-					&& distance == 3
-					&& _action.target.z != _action.actor->getPosition().z)
+				// special handling for maxRange 2: allow it to target diagonally adjacent tiles (one diagonal move + one straight move)
+				else if (weapon->getRules()->getMaxRange() == 2 && distanceSq <= 6)
 				{
 					break;
 				}

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -1011,7 +1011,8 @@ int TileEngine::determineReactionType(BattleUnit *unit, BattleUnit *target)
 		// has a gun capable of snap shot with ammo
 		(weapon->getRules()->getBattleType() != BT_MELEE &&
 		weapon->getRules()->getTUSnap() &&
-		distance(unit->getPosition(), target->getPosition()) < weapon->getRules()->getMaxRange() &&
+		// Note: distance calculation isn't precise for 2x2 units here, but changing it would likely require also changing the targeting of 2x2 units
+		distanceSq(unit->getPosition(), target->getPosition(), false) < weapon->getRules()->getMaxRangeSq() &&
 		weapon->getAmmoItem() &&
 		unit->getActionTUs(BA_SNAPSHOT, weapon) > 0 &&
 		unit->getTimeUnits() > unit->getActionTUs(BA_SNAPSHOT, weapon)) &&
@@ -2637,6 +2638,28 @@ void TileEngine::togglePersonalLighting()
 {
 	_personalLighting = !_personalLighting;
 	calculateUnitLighting();
+}
+
+/**
+ * Calculates the distance squared between a unit and a point position.
+ * @param unit The unit.
+ * @param pos The point position.
+ * @param considerZ Whether to consider the z coordinate.
+ * @return Distance squared.
+ */
+int TileEngine::distanceUnitToPositionSq(BattleUnit* unit, const Position& pos, bool considerZ) const
+{
+	int x = unit->getPosition().x - pos.x;
+	int y = unit->getPosition().y - pos.y;
+	int z = considerZ ? (unit->getPosition().z - pos.z) : 0;
+	if (unit->getArmor()->getSize() > 1)
+	{
+		if (unit->getPosition().x < pos.x)
+			x++;
+		if (unit->getPosition().y < pos.y)
+			y++;
+	}
+	return x*x + y*y + z*z;
 }
 
 /**

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -90,6 +90,8 @@ public:
 	bool visible(BattleUnit *currentUnit, Tile *tile);
 	/// Turn XCom soldier's personal lighting on or off.
 	void togglePersonalLighting();
+	/// Checks the distance squared between a unit and a position.
+	int distanceUnitToPositionSq(BattleUnit* unit, const Position& pos, bool considerZ) const;
 	/// Checks the distance between two positions.
 	int distance(Position pos1, Position pos2) const;
 	/// Checks the distance squared between two positions.

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -675,6 +675,15 @@ int RuleItem::getMaxRange() const
 }
 
 /**
+ * Gets the maximum range of this weapon squared
+ * @return The maximum range squared.
+ */
+int RuleItem::getMaxRangeSq() const
+{
+	return _maxRange * _maxRange;
+}
+
+/**
  * Gets the maximum effective range of this weapon when using Aimed Shot.
  * @return The maximum range.
  */

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -192,6 +192,8 @@ public:
 	bool isPistol() const;
 	/// Get the max range of this weapon.
 	int getMaxRange() const;
+	/// Get the max range of this weapon squared.
+	int getMaxRangeSq() const;
 	/// Get the max range of aimed shots with this weapon.
 	int getAimRange() const;
 	/// Get the max range of snap shots with this weapon.


### PR DESCRIPTION
Updated ONLY the calculations related to maxRange attribute of ranged weapons.
These calculations don't exist in the OG, relevant only for mods.

All other distance calculations were unchanged,
difference of +/-1 doesn't mean much in them anyway.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->