### PR TITLE
E2K: fixed build by MCST lcc compiler

### DIFF
--- a/src/Engine/Zoom.cpp
+++ b/src/Engine/Zoom.cpp
@@ -634,7 +634,13 @@ bool Zoom::haveSSE2()
 {
 #ifdef __GNUC__
 	unsigned int CPUInfo[4] = {0, 0, 0, 0};
-	__get_cpuid(1, CPUInfo, CPUInfo+1, CPUInfo+2, CPUInfo+3);
+	#if (__i386__ || __x86_64__)
+		__get_cpuid(1, CPUInfo, CPUInfo+1, CPUInfo+2, CPUInfo+3);
+	#elif (__e2k__)
+		#ifdef __SSE2__
+			CPUInfo[3] = 0x04000000;
+		#endif
+	#endif
 #elif _WIN32
 	int CPUInfo[4];
 	__cpuid(CPUInfo, 1);


### PR DESCRIPTION
MCST E2K (Elbrus 2000) - this is VLIW/EPIC architecture, like Intel Itanium (IA-64) architecture.
Ref: https://en.wikipedia.org/wiki/Elbrus_2000

e2k architecture has half native / half software support of most Intel/AMD SIMD
e.g. MMX/SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2/AES/AVX/AVX2 & 3DNow!/SSE4a/XOP/FMA4

This PR fixes the error "`__get_cpuid is undefined`" (line 637: error # 20), because e2k does not have an x86 CPUID instruction.