### PR TITLE
src/Engine/Zoom.cpp: updated Zoom::haveSSE2 check for e2k

### DIFF
--- a/src/Engine/Zoom.cpp
+++ b/src/Engine/Zoom.cpp
@@ -634,12 +634,12 @@ bool Zoom::haveSSE2()
 {
 #ifdef __GNUC__
 	unsigned int CPUInfo[4] = {0, 0, 0, 0};
-	#if (__i386__ || __x86_64__)
-		__get_cpuid(1, CPUInfo, CPUInfo+1, CPUInfo+2, CPUInfo+3);
-	#elif (__e2k__)
+	#if (__e2k__) // e2k - MCST Elbrus 2000 architecture
 		#ifdef __SSE2__
 			CPUInfo[3] = 0x04000000;
 		#endif
+	#else // i386/x86_64
+		__get_cpuid(1, CPUInfo, CPUInfo+1, CPUInfo+2, CPUInfo+3);
 	#endif
 #elif _WIN32
 	int CPUInfo[4];


### PR DESCRIPTION
Made a slight improvement to the architecture detection algorithm in the `Zoom::haveSSE2()` function.