### PR TITLE
Typo fix (fixes unability to launch TFTD)

### DIFF
--- a/bin/standard/xcom2/vars.rul
+++ b/bin/standard/xcom2/vars.rul
@@ -18,7 +18,7 @@ alienFuel: [STR_ZRBITE, 50]
 fontName: Font.dat
 
 constants: #done
-  doorSound: 47
+- doorSound: 47
   slidingDoorSound: 46
   slidingDoorClose: -1
   smallExplosion: 30


### PR DESCRIPTION
A minor fix (possibly a mistyping) that caused TFTD fail to start