### PR TITLE
Add more support for diffrent OXC engine versions

### DIFF
--- a/bin/common/Language/en-GB.yml
+++ b/bin/common/Language/en-GB.yml
@@ -248,7 +248,7 @@ en-GB:
   STR_ALIEN_RACE: "Race"
   STR_ALIEN_TECH_LEVEL: "Tech Level"
   STR_RANDOMIZE: "Randomize"
-  STR_OXCE_REQUIRED_QUESTION: "This mod requires OpenXcom Extended to run correctly. Enable this mod?"
+  STR_OXCE_REQUIRED_QUESTION: "This mod requires OpenXcom {0} to run correctly. Enable this mod?"
   STR_RESTORE_DEFAULTS_QUESTION: "Are you sure you want to restore the default options?"
   STR_DISPLAY_OPTIONS_CONFIRM: "Do you want to keep the current display options?"
   STR_DISPLAY_OPTIONS_REVERT: "Reverting in 0:{0}"

--- a/bin/common/Language/en-US.yml
+++ b/bin/common/Language/en-US.yml
@@ -248,7 +248,7 @@ en-US:
   STR_ALIEN_RACE: "Race"
   STR_ALIEN_TECH_LEVEL: "Tech Level"
   STR_RANDOMIZE: "Randomize"
-  STR_OXCE_REQUIRED_QUESTION: "This mod requires OpenXcom Extended to run correctly. Enable this mod?"
+  STR_OXCE_REQUIRED_QUESTION: "This mod requires OpenXcom {0} to run correctly. Enable this mod?"
   STR_RESTORE_DEFAULTS_QUESTION: "Are you sure you want to restore the default options?"
   STR_DISPLAY_OPTIONS_CONFIRM: "Do you want to keep the current display options?"
   STR_DISPLAY_OPTIONS_REVERT: "Reverting in 0:{0}"

--- a/src/Engine/ModInfo.h
+++ b/src/Engine/ModInfo.h
@@ -33,6 +33,8 @@ private:
 	std::string _name, _desc, _version, _author, _url, _id, _master;
 	bool _isMaster;
 	int _reservedSpace;
+	bool _engineOk;
+	std::string _requiredExtendedEngine;
 	std::string _requiredExtendedVersion;
 	std::string _resourceConfigFile;
 	std::vector<std::string> _externalResourceDirs;
@@ -62,6 +64,10 @@ public:
 	bool canActivate(const std::string &curMaster) const;
 	/// Gets size of mod, bigger mod reserve more values in common collections/surfacesets.
 	int getReservedSpace() const;
+	/// Is mod compatible with current OXCE engine aka "fork".
+	bool isEngineOk() const;
+	/// Gets the OXCE engine (like "FtA" or "Extended") required by this mod.
+	const std::string &getRequiredExtendedEngine() const;
 	/// Gets the OXCE version required by this mod.
 	const std::string &getRequiredExtendedVersion() const;
 	/// Gets ruleset file where are defined based resources like required original game data.

--- a/src/Menu/ModConfirmExtendedState.cpp
+++ b/src/Menu/ModConfirmExtendedState.cpp
@@ -20,6 +20,7 @@
 #include "../Engine/Game.h"
 #include "../Engine/LocalizedText.h"
 #include "../Engine/Options.h"
+#include "../Engine/ModInfo.h"
 #include "../Interface/Text.h"
 #include "../Interface/TextButton.h"
 #include "../Interface/Window.h"
@@ -32,9 +33,9 @@ namespace OpenXcom
 	/**
 	 * Initializes all the elements in the Confirm OXCE screen.
 	 * @param state Pointer to the Options|Mod state.
-	 * @param isMaster Are we enabling a standard mod or a master mod?
+	 * @param modInfo What exactly mod caused this question?
 	 */
-	ModConfirmExtendedState::ModConfirmExtendedState(ModListState *state, bool isMaster) : _state(state), _isMaster(isMaster)
+	ModConfirmExtendedState::ModConfirmExtendedState(ModListState *state, const ModInfo *modInfo) : _state(state), _isMaster(modInfo->isMaster())
 	{
 		_screen = false;
 
@@ -66,7 +67,7 @@ namespace OpenXcom
 		_txtTitle->setAlign(ALIGN_CENTER);
 		_txtTitle->setBig();
 		_txtTitle->setWordWrap(true);
-		_txtTitle->setText(tr("STR_OXCE_REQUIRED_QUESTION"));
+		_txtTitle->setText(tr("STR_OXCE_REQUIRED_QUESTION").arg(modInfo->getRequiredExtendedEngine()));
 	}
 
 	/**

--- a/src/Menu/ModConfirmExtendedState.h
+++ b/src/Menu/ModConfirmExtendedState.h
@@ -22,6 +22,7 @@
 namespace OpenXcom
 {
 	class ModListState;
+	class ModInfo;
 	class TextButton;
 	class Window;
 	class Text;
@@ -40,7 +41,7 @@ namespace OpenXcom
 		Text *_txtTitle;
 	public:
 		/// Creates the Confirm OXCE state.
-		ModConfirmExtendedState(ModListState *state, bool isMaster);
+		ModConfirmExtendedState(ModListState *state, const ModInfo *modInfo);
 		/// Cleans up the Confirm OXCE state.
 		~ModConfirmExtendedState();
 		/// Handler for clicking the Yes button.

--- a/src/Menu/ModListState.cpp
+++ b/src/Menu/ModListState.cpp
@@ -167,9 +167,9 @@ void ModListState::cbxMasterChange(Action *)
 
 	// when changing a master mod, check if it requires OXCE
 	{
-		if (!masterModInfo->getRequiredExtendedVersion().empty())
+		if (!masterModInfo->isEngineOk())
 		{
-			_game->pushState(new ModConfirmExtendedState(this, true));
+			_game->pushState(new ModConfirmExtendedState(this, masterModInfo));
 			return;
 		}
 	}
@@ -250,9 +250,9 @@ void ModListState::lstModsClick(Action *action)
 	if (!mod.second)
 	{
 		const ModInfo *modInfo = &Options::getModInfos().at(mod.first);
-		if (!modInfo->getRequiredExtendedVersion().empty())
+		if (!modInfo->isEngineOk())
 		{
-			_game->pushState(new ModConfirmExtendedState(this, false));
+			_game->pushState(new ModConfirmExtendedState(this, modInfo));
 			return;
 		}
 	}

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -575,6 +575,7 @@ void SavedGame::save(const std::string &filename) const
 	YAML::Node brief;
 	brief["name"] = _name;
 	brief["version"] = OPENXCOM_VERSION_SHORT;
+	brief["engine"] = OPENXCOM_VERSION_ENGINE;
 	std::string git_sha = OPENXCOM_VERSION_GIT;
 	if (!git_sha.empty() && git_sha[0] ==  '.')
 	{

--- a/src/version.h
+++ b/src/version.h
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#define OPENXCOM_VERSION_ENGINE ""
 #define OPENXCOM_VERSION_SHORT "1.0"
 #define OPENXCOM_VERSION_LONG "1.0.0.0"
 #define OPENXCOM_VERSION_NUMBER 1,0,0,0


### PR DESCRIPTION
Option for mods to define what "engine" of OXC mode require.
Now we have at least two version Extended and FtA and soon there could be more.

As different engines can support different set of mechanics, in some cases incompatible, we need universal
way to distinguish between them.

`supportedEngines` declare list of other engines that are supported (like FtA could support mods from Extended)
`OPENXCOM_VERSION_ENGINE` Is name of current engine.