### PR TITLE
Add corrected man page installation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 find_program ( DOXYGEN_EXECUTABLE
   NAMES doxygen
   DOC "Doxygen program" )
@@ -34,4 +36,9 @@ if ( NOT ( DOXYGEN_EXECUTABLE MATCHES "NOTFOUND" ) )
     COMMENT "Generating doxygen documentation" )
 else ()
   message ( "No doxygen command found. Disable API documentation generation" )
+endif ()
+
+# Only useful for make install/package under *nix OSes, but not macOS.
+if ( UNIX AND NOT APPLE )
+    INSTALL(FILES openxcom.6 DESTINATION ${CMAKE_INSTALL_MANDIR}/man6)
 endif ()


### PR DESCRIPTION
Use the built-in module GNUInstallDirs ([doc link](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html)) to determine install path, which provides sane defaults per OS, as well as allowing overriding by package maintainers.

For example, one can override the default by specifying `cmake -DCMAKE_INSTALL_MANDIR=<path>` (e.g. "share/man" or "/var/lib/manpages/foo").

This is a partial revert of f8d860d7727ec6c7f8eed2d9e4cf9f83725d17a0 (fixes the path rather than removing it).

To address the other complaint in the commit message re: compression: As a package maintainer myself, I've seen very few install scripts that compress man pages. In fact, when it does happen, the compression method used is often wrong (default compression vs. max), or geared toward one specific distro/OS (e.g. bz2 vs. gzip). Compressing man pages on install is really not expected or required. :-)