### PR TITLE
Prevent lines going missing when trying to scroll when not needed.

### DIFF
--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -1230,6 +1230,8 @@ void TextList::scrollTo(size_t scroll)
 {
 	if (!_scrolling)
 		return;
+	if (_rows.size() <= _visibleRows)
+		return;
 	_scroll = Clamp(scroll, (size_t)(0), _rows.size() - _visibleRows);
 	draw(); // can't just set _redraw here because reasons
 	updateArrows();


### PR DESCRIPTION
This PR causes `TextList::scrollTo()` to return early when scrolling is not needed.

This should prevent a 'bug' where lines go missing when programmatically trying to scroll lists smaller than allocated for.

-- edit --
Please disregard last line of commit message. I've misinterpreted original behavior.
Unintentional hiding of lines due to scroll still seems like an error to me though.