### PR TITLE
Fix memory leak on rule `delete:`

### DIFF
--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -1617,6 +1617,7 @@ T *Mod::loadRule(const YAML::Node &node, std::map<std::string, T*> *map, std::ve
 		typename std::map<std::string, T*>::iterator i = map->find(type);
 		if (i != map->end())
 		{
+			delete i->second;
 			map->erase(i);
 		}
 		if (index != 0)

--- a/src/Mod/RuleTerrain.cpp
+++ b/src/Mod/RuleTerrain.cpp
@@ -63,6 +63,10 @@ void RuleTerrain::load(const YAML::Node &node, Mod *mod)
 	}
 	if (const YAML::Node &map = node["mapBlocks"])
 	{
+		for (std::vector<MapBlock*>::iterator i = _mapBlocks.begin(); i != _mapBlocks.end(); ++i)
+		{
+			delete *i;
+		}
 		_mapBlocks.clear();
 		for (YAML::const_iterator i = map.begin(); i != map.end(); ++i)
 		{

--- a/src/Mod/RuleTerrain.cpp
+++ b/src/Mod/RuleTerrain.cpp
@@ -31,6 +31,8 @@ namespace OpenXcom
  */
 RuleTerrain::RuleTerrain(const std::string &name) : _name(name), _script("DEFAULT"), _minDepth(0), _maxDepth(0), _ambience(-1), _ambientVolume(0.5)
 {
+	_civilianTypes.push_back("MALE_CIVILIAN");
+	_civilianTypes.push_back("FEMALE_CIVILIAN");
 }
 
 /**
@@ -73,11 +75,6 @@ void RuleTerrain::load(const YAML::Node &node, Mod *mod)
 	if (const YAML::Node &civs = node["civilianTypes"])
 	{
 		_civilianTypes = civs.as<std::vector<std::string> >(_civilianTypes);
-	}
-	else
-	{
-		_civilianTypes.push_back("MALE_CIVILIAN");
-		_civilianTypes.push_back("FEMALE_CIVILIAN");
 	}
 	for (YAML::const_iterator i = node["music"].begin(); i != node["music"].end(); ++i)
 	{


### PR DESCRIPTION
When rule is removed object stay in memory not deleted and effective leak memory.
As this happens only during load and mode need use `delete:`, amount of leaked memory is limited.