### PR TITLE
Fix possible bug when tile below GravLift was void

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -2555,7 +2555,7 @@ VoxelType TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool e
 
 	if (tile->getMapData(O_FLOOR) && tile->getMapData(O_FLOOR)->isGravLift() && (voxel.z % 24 == 0 || voxel.z % 24 == 1))
 	{
-		if ((tile->getPosition().z == 0) || (tileBelow && tileBelow->getMapData(O_FLOOR) && !tileBelow->getMapData(O_FLOOR)->isGravLift()))
+		if (!(tileBelow && tileBelow->getMapData(O_FLOOR) && tileBelow->getMapData(O_FLOOR)->isGravLift()))
 		{
 			return V_FLOOR;
 		}


### PR DESCRIPTION
If below tile do not have floor whole test would be `false` and this could make GravLift floor above consider not hit.

(backport of commit 29f6bc520c9ef374f0ec701694d5e78c75dd7ea1)