### PR TITLE
Fix globe memory allocation

### DIFF
--- a/src/Engine/GraphSubset.h
+++ b/src/Engine/GraphSubset.h
@@ -51,13 +51,6 @@ struct GraphSubset
 
 	}
 
-	GraphSubset(const GraphSubset& r):
-			beg_x(r.beg_x), end_x(r.end_x),
-			beg_y(r.beg_y), end_y(r.end_y)
-	{
-
-	}
-
 	inline GraphSubset offset(int x, int y) const
 	{
 		GraphSubset ret = *this;

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -178,6 +178,7 @@ void create()
 	_info.push_back(OptionInfo("canSellLiveAliens", &canSellLiveAliens, false, "STR_CANSELLLIVEALIENS", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("anytimePsiTraining", &anytimePsiTraining, false, "STR_ANYTIMEPSITRAINING", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("globeSeasons", &globeSeasons, false, "STR_GLOBESEASONS", "STR_GEOSCAPE"));
+	_info.push_back(OptionInfo("globeSurfaceCache", &globeSurfaceCache, true)); //hidden for now
 	_info.push_back(OptionInfo("psiStrengthEval", &psiStrengthEval, false, "STR_PSISTRENGTHEVAL", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("canTransferCraftsWhileAirborne", &canTransferCraftsWhileAirborne, false, "STR_CANTRANSFERCRAFTSWHILEAIRBORNE", "STR_GEOSCAPE")); // When the craft can reach the destination base with its fuel
 	_info.push_back(OptionInfo("retainCorpses", &retainCorpses, false, "STR_RETAINCORPSES", "STR_GEOSCAPE"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -21,7 +21,8 @@ OPT SDLKey keyOk, keyCancel, keyScreenshot, keyFps, keyQuickLoad, keyQuickSave;
 
 // Geoscape options
 OPT int geoClockSpeed, dogfightSpeed, geoScrollSpeed, geoDragScrollButton, geoscapeScale;
-OPT bool includePrimeStateInSavedLayout, anytimePsiTraining, weaponSelfDestruction, retainCorpses, craftLaunchAlways, globeSeasons, globeDetail, globeRadarLines, globeFlightPaths, globeAllRadarsOnBaseBuild,
+OPT bool includePrimeStateInSavedLayout, anytimePsiTraining, weaponSelfDestruction, retainCorpses, craftLaunchAlways,
+	globeSurfaceCache, globeSeasons, globeDetail, globeRadarLines, globeFlightPaths, globeAllRadarsOnBaseBuild,
 	storageLimitsEnforced, canSellLiveAliens, canTransferCraftsWhileAirborne, customInitialBase, aggressiveRetaliation, geoDragScrollInvert,
 	allowBuildingQueue, showFundsOnGeoscape, psiStrengthEval, allowPsiStrengthImprovement, fieldPromotions, meetingPoint;
 OPT SDLKey keyGeoLeft, keyGeoRight, keyGeoUp, keyGeoDown, keyGeoZoomIn, keyGeoZoomOut, keyGeoSpeed1, keyGeoSpeed2, keyGeoSpeed3, keyGeoSpeed4, keyGeoSpeed5, keyGeoSpeed6,

--- a/src/Engine/ShaderDrawHelper.h
+++ b/src/Engine/ShaderDrawHelper.h
@@ -50,6 +50,20 @@ public:
 	}
 };
 
+/**
+ * 2d offset, return offset of given pixel to some predetermined position in 2d space.
+ */
+class Offset
+{
+public:
+	int x;
+	int y;
+
+	inline Offset(int xx, int yy) : x(xx), y(yy)
+	{
+
+	}
+};
 
 /**
  * This is surface argument to `ShaderDraw`.
@@ -503,6 +517,71 @@ struct controler<Scalar<T> >
 		return ref;
 	}
 };
+
+/// implementation for offset
+template<>
+struct controler<Offset>
+{
+	const Offset off;
+	int pos_x;
+	int pos_y;
+	int start_x;
+	int start_y;
+
+	inline controler(Offset s) : off(s),
+		pos_x(), pos_y(),
+		start_x(), start_y()
+	{
+
+	}
+
+	//cant use this function
+	//inline GraphSubset get_range()
+
+	inline void mod_range(GraphSubset&)
+	{
+		//nothing
+	}
+
+	inline void set_range(const GraphSubset& r)
+	{
+		start_x = r.beg_x - off.x;
+		start_y = r.beg_y - off.y;
+	}
+
+	inline void mod_y(int&, int&)
+	{
+		pos_y = start_y;
+	}
+	inline void set_y(const int& begin, const int&)
+	{
+		pos_y += begin;
+	}
+	inline void inc_y()
+	{
+		pos_y += 1;
+	}
+
+
+	inline void mod_x(int&, int&)
+	{
+		pos_x = start_x;
+	}
+	inline void set_x(const int& begin, const int&)
+	{
+		pos_x += begin;
+	}
+	inline void inc_x()
+	{
+		pos_x += 1;
+	}
+
+	inline Offset get_ref()
+	{
+		return Offset(pos_x, pos_y);
+	}
+};
+
 
 /// implementation for not used arg
 template<>

--- a/src/Geoscape/Cord.h
+++ b/src/Geoscape/Cord.h
@@ -33,11 +33,6 @@ struct CordPolar
 		lon = plon;
 		lat = plat;
 	}
-	inline CordPolar(const CordPolar& pol)
-	{
-		lon = pol.lon;
-		lat = pol.lat;
-	}
 	inline CordPolar()
 	{
 		lon = 0;
@@ -55,12 +50,6 @@ struct Cord
 		x = px;
 		y = py;
 		z = pz;
-	}
-	inline Cord(const Cord& c)
-	{
-		x = c.x;
-		y = c.y;
-		z = c.z;
 	}
 	inline Cord()
 	{


### PR DESCRIPTION
Some users have "unreasonable" screen sizes like 5120x2160, this scale poorly with globe cache.
Added hidden config to disable cache.