### PR TITLE
Unified usage of Armor.spriteInv across all UIs

### DIFF
--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -340,11 +340,23 @@ void InventoryState::init()
 		{
 			look = s->getArmor()->getSpriteInventory() + ".SPK";
 		}
+		if (!_game->getMod()->getSurface(look, false))
+		{
+			look = s->getArmor()->getSpriteInventory();
+		}
 		_game->getMod()->getSurface(look)->blit(_soldier);
 	}
 	else
 	{
 		Surface *armorSurface = _game->getMod()->getSurface(unit->getArmor()->getSpriteInventory(), false);
+		if (!armorSurface)
+		{
+			armorSurface = _game->getMod()->getSurface(unit->getArmor()->getSpriteInventory() + ".SPK", false);
+		}
+		if (!armorSurface)
+		{
+			armorSurface = _game->getMod()->getSurface(unit->getArmor()->getSpriteInventory() + "M0.SPK", false);
+		}
 		if (armorSurface)
 		{
 			armorSurface->blit(_soldier);

--- a/src/Ufopaedia/ArticleStateArmor.cpp
+++ b/src/Ufopaedia/ArticleStateArmor.cpp
@@ -70,6 +70,10 @@ namespace OpenXcom
 		{
 			look = armor->getSpriteInventory() + ".SPK";
 		}
+		if (!_game->getMod()->getSurface(look, false))
+		{
+			look = armor->getSpriteInventory();
+		}
 		_game->getMod()->getSurface(look)->blit(_image);
 
 


### PR DESCRIPTION
https://openxcom.org/forum/index.php/topic,2027.msg149369.html#msg149369

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->