### PR TITLE
Fix bug with all units' voxels flipped relative to Y axis

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -355,7 +355,7 @@ bool TileEngine::calculateFOV(BattleUnit *unit)
 }
 
 /**
- * Gets the origin voxel of a unit's eyesight (from just one eye or something? Why is it x+7??
+ * Gets the origin voxel of a unit's eyesight
  * @param currentUnit The watcher.
  * @return Approximately an eyeball voxel.
  */
@@ -363,7 +363,7 @@ Position TileEngine::getSightOriginVoxel(BattleUnit *currentUnit)
 {
 	// determine the origin and target voxels for the raytrace
 	Position originVoxel;
-	originVoxel = Position((currentUnit->getPosition().x * 16) + 7, (currentUnit->getPosition().y * 16) + 8, currentUnit->getPosition().z*24);
+	originVoxel = Position((currentUnit->getPosition().x * 16) + 8, (currentUnit->getPosition().y * 16) + 8, currentUnit->getPosition().z*24);
 	originVoxel.z += -_save->getTile(currentUnit->getPosition())->getTerrainLevel();
 	originVoxel.z += currentUnit->getHeight() + currentUnit->getFloatHeight() - 1; //one voxel lower (eye level)
 	Tile *tileAbove = _save->getTile(currentUnit->getPosition() + Position(0,0,1));
@@ -459,7 +459,7 @@ bool TileEngine::visible(BattleUnit *currentUnit, Tile *tile)
  */
 int TileEngine::checkVoxelExposure(Position *originVoxel, Tile *tile, BattleUnit *excludeUnit, BattleUnit *excludeAllBut)
 {
-	Position targetVoxel = Position((tile->getPosition().x * 16) + 7, (tile->getPosition().y * 16) + 8, tile->getPosition().z * 24);
+	Position targetVoxel = Position((tile->getPosition().x * 16) + 8, (tile->getPosition().y * 16) + 8, tile->getPosition().z * 24);
 	Position scanVoxel;
 	std::vector<Position> _trajectory;
 	BattleUnit *otherUnit = tile->getUnit();
@@ -538,7 +538,7 @@ int TileEngine::checkVoxelExposure(Position *originVoxel, Tile *tile, BattleUnit
  */
 bool TileEngine::canTargetUnit(Position *originVoxel, Tile *tile, Position *scanVoxel, BattleUnit *excludeUnit, bool rememberObstacles, BattleUnit *potentialUnit)
 {
-	Position targetVoxel = Position((tile->getPosition().x * 16) + 7, (tile->getPosition().y * 16) + 8, tile->getPosition().z * 24);
+	Position targetVoxel = Position((tile->getPosition().x * 16) + 8, (tile->getPosition().y * 16) + 8, tile->getPosition().z * 24);
 	std::vector<Position> _trajectory;
 	bool hypothetical = potentialUnit != 0;
 	if (potentialUnit == 0)
@@ -2612,13 +2612,14 @@ VoxelType TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool e
 			int tz = unitpos.z*24 + unit->getFloatHeight() - terrainHeight; //bottom most voxel, terrain heights are negative, so we subtract.
 			if ((voxel.z > tz) && (voxel.z <= tz + unit->getHeight()) )
 			{
-				int x = voxel.x%16;
+				int x = 15 - voxel.x%16;
 				int y = voxel.y%16;
 				int part = 0;
 				if (unit->getArmor()->getSize() > 1)
 				{
 					tilepos = tile->getPosition();
-					part = tilepos.x - unitpos.x + (tilepos.y - unitpos.y)*2;
+					constexpr static int parts[] = {1,0,3,2}; // Change order 0,1,2,3 -> 1,0,3,2  (read commit description)
+					part = parts[tilepos.x - unitpos.x + (tilepos.y - unitpos.y)*2];
 				}
 				int idx = (unit->getLoftemps(part) * 16) + y;
 				if (_voxelData->at(idx) & (1 << x))

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -2618,7 +2618,7 @@ VoxelType TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool e
 				if (unit->getArmor()->getSize() > 1)
 				{
 					tilepos = tile->getPosition();
-					constexpr static int parts[] = {1,0,3,2}; // Change order 0,1,2,3 -> 1,0,3,2  (read commit description)
+					const static int parts[] = {1,0,3,2}; // Change order 0,1,2,3 -> 1,0,3,2  (read commit description)
 					part = parts[tilepos.x - unitpos.x + (tilepos.y - unitpos.y)*2];
 				}
 				int idx = (unit->getLoftemps(part) * 16) + y;


### PR DESCRIPTION
Sometimes TileEngine::calculateLineVoxel() successfully creates the trajectory to voxel inside a unit, but returns V_EMPTY instead of V_UNIT. As it turned out, LOFTemps data is stored in memory in "right" direction, with positive X axis from left to right, but (1 << x) in code counts X axis in negative direction, from right to left. LOFTemp becomes [effectively inverted from left to right](https://cdn.discordapp.com/attachments/292085473890009088/1138261841575948348/image.png), which moves unit slightly to the left. For terrain code, this effect negated by inverting X axis beforehand, just like that:

`int x = 15 - voxel.x%16;`
`int y = voxel.y%16;`

but the unit check does:

`int x = voxel.x%16;`
`int y = voxel.y%16;`

[Also, in original X-Com it was 0x8000 >> x](https://media.discordapp.net/attachments/292085473890009088/1138080727494295623/image.png) - just shifting X in positive direction, without double inverting it

Current 2x2 units loftemps loading logic is inverted too, so I've added workaround to not break anything (switching left/right parts).

Inverted units have new center at (7,8) - Volutar has deducted that empirically somehow and "fixed" in 
https://github.com/OpenXcom/OpenXcom/commit/757d67404eebc289ea8df26e3b7aa4c0be495f25 so I reverted those too.

Images [before](https://cdn.discordapp.com/attachments/292085473890009088/1138262212939612311/fpslook055.png) and [after](https://cdn.discordapp.com/attachments/292085473890009088/1138262213212246057/fpslook0552.png) a patch.
