### PR TITLE
Update PostprocessBundle.cmake to include /opt/homebrew/lib

### DIFF
--- a/cmake/modules/PostprocessBundle.cmake
+++ b/cmake/modules/PostprocessBundle.cmake
@@ -36,7 +36,7 @@ file(GLOB_RECURSE extra_libs "${BUNDLE_PATH}/Contents/MacOS/*.dylib")
 # makes it sometimes break on libraries that do weird things with @rpath. Specify
 # equivalent search directories until https://gitlab.kitware.com/cmake/cmake/issues/16625
 # is fixed and in our minimum CMake version.
-set(extra_dirs "/usr/local/lib" "/lib" "/usr/lib")
+set(extra_dirs "/opt/homebrew/lib" "/usr/local/lib" "/lib" "/usr/lib")
 
 # BundleUtilities is overly verbose, so disable most of its messages
 function(message)


### PR DESCRIPTION
Homebrew on macOS arm64 lives in `/opt/homebrew` per default. Add `/opt/homebrew/lib` to PostprocessBundle.cmake's `extra_dirs`. Without this, `libsharpyuv.0.dylib` cannot be found during bundeling resulting in the following error:
```
CMake Error at /Users/xxx/Sources/OpenXcom/cmake/modules/PostprocessBundle.cmake:44 (_message):
  otool -l failed: 1

  error: /Library/Developer/CommandLineTools/usr/bin/otool-classic: can't
  open file: @rpath/libsharpyuv.0.dylib (No such file or directory)

Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.27.4/share/cmake/Modules/BundleUtilities.cmake:458 (message)
  /opt/homebrew/Cellar/cmake/3.27.4/share/cmake/Modules/BundleUtilities.cmake:527 (get_item_rpaths)
  /opt/homebrew/Cellar/cmake/3.27.4/share/cmake/Modules/BundleUtilities.cmake:649 (set_bundle_key_values)
  /opt/homebrew/Cellar/cmake/3.27.4/share/cmake/Modules/BundleUtilities.cmake:933 (get_bundle_keys)
  /Users/xxx/Sources/OpenXcom/cmake/modules/PostprocessBundle.cmake:50 (fixup_bundle)


make[2]: *** [openxcom.app/Contents/MacOS/openxcom] Error 1
make[2]: *** Deleting file `openxcom.app/Contents/MacOS/openxcom'
make[1]: *** [src/CMakeFiles/openxcom.dir/all] Error 2
make: *** [all] Error 2
```

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->