### PR TITLE
fix: remove discrepancy between displayed and real accuracy

### DIFF
--- a/src/Battlescape/Projectile.cpp
+++ b/src/Battlescape/Projectile.cpp
@@ -335,7 +335,8 @@ void Projectile::applyAccuracy(Position origin, Position *target, double accurac
 {
 	int xdiff = origin.x - target->x;
 	int ydiff = origin.y - target->y;
-	double realDistance = sqrt((double)(xdiff*xdiff)+(double)(ydiff*ydiff));
+	int zdiff = origin.z - target->z;
+	double realDistance = std::ceil( sqrt( (double)(xdiff*xdiff + ydiff*ydiff + zdiff*zdiff) ));
 	// maxRange is the maximum range a projectile shall ever travel in voxel space
 	double maxRange = keepRange?realDistance:16*1000; // 1000 tiles
 	maxRange = _action.type == BA_HIT?46:maxRange; // up to 2 tiles diagonally (as in the case of reaper v reaper)
@@ -344,6 +345,7 @@ void Projectile::applyAccuracy(Position origin, Position *target, double accurac
 	if (_action.type != BA_THROW && _action.type != BA_HIT)
 	{
 		double modifier = 0.0;
+		double tilesDistance = std::ceil(realDistance / 16);
 		int upperLimit = weapon->getAimRange();
 		int lowerLimit = weapon->getMinRange();
 		if (Options::battleUFOExtenderAccuracy)
@@ -357,13 +359,13 @@ void Projectile::applyAccuracy(Position origin, Position *target, double accurac
 				upperLimit = weapon->getSnapRange();
 			}
 		}
-		if (realDistance / 16 < lowerLimit)
+		if (tilesDistance < lowerLimit)
 		{
-			modifier = (weapon->getDropoff() * (lowerLimit - realDistance / 16)) / 100;
+			modifier = (weapon->getDropoff() * (lowerLimit - tilesDistance)) / 100;
 		}
-		else if (upperLimit < realDistance / 16)
+		else if (upperLimit < tilesDistance)
 		{
-			modifier = (weapon->getDropoff() * (realDistance / 16 - upperLimit)) / 100;
+			modifier = (weapon->getDropoff() * (tilesDistance - upperLimit)) / 100;
 		}
 		accuracy = std::max(0.0, accuracy - modifier);
 	}


### PR DESCRIPTION
Code for displayed accuracy (for UFO Extender option) differs from the actual accuracy calculation inside Projectile::applyAccuracy(), with different rounding. What's more important, displayed number in Map::drawTerrain() is calculated in 3D space, and applyAccuracy ignores z-coordinates whatsoever, so displayed number is actually more precise. This fix makes those numbers in line with each other.

Changes aren't "pure cosmetic", especially with corner cases - game won't consider target which is 8 levels above targeting unit, as adjanced for accuracy calculation.
<!--

Guidelines for pull requests:

* Use a separate branch (instead of "master"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been throughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->