### PR TITLE
Add option to skip units with 0TU

### DIFF
--- a/bin/common/Language/en-GB.yml
+++ b/bin/common/Language/en-GB.yml
@@ -280,6 +280,8 @@ en-GB:
   STR_NOALIENPANICMESSAGES_DESC: "Don't show panic messages for aliens unless they are visible to the player."
   STR_ALIENBLEEDING: "Alien bleeding"
   STR_ALIENBLEEDING_DESC: "Allows fatal wounds to be inflicted on most aliens."
+  STR_SKIPOUTOFTIME: "Don't reselect units who are out of time"
+  STR_SKIPOUTOFTIME_DESC: "When the \"don't reselect unit\" button is pressed, skip units who have zero time units remaining."
   STR_FIELDPROMOTIONS: "Field promotions"
   STR_FIELDPROMOTIONS_DESC: "Only soldiers that were present at the mission site are eligible for promotion."
   STR_MEETINGPOINT: "Predict UFO trajectory"

--- a/bin/common/Language/en-US.yml
+++ b/bin/common/Language/en-US.yml
@@ -280,6 +280,8 @@ en-US:
   STR_NOALIENPANICMESSAGES_DESC: "Don't show panic messages for aliens unless they are visible to the player."
   STR_ALIENBLEEDING: "Alien bleeding"
   STR_ALIENBLEEDING_DESC: "Allows fatal wounds to be inflicted on most aliens."
+  STR_SKIPOUTOFTIME: "Don't reselect units who are out of time"
+  STR_SKIPOUTOFTIME_DESC: "When the \"don't reselect unit\" button is pressed, skip units who have zero time units remaining."
   STR_FIELDPROMOTIONS: "Field promotions"
   STR_FIELDPROMOTIONS_DESC: "Only soldiers that were present at the mission site are eligible for promotion."
   STR_MEETINGPOINT: "Predict UFO trajectory"

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -205,6 +205,7 @@ void create()
 	_info.push_back(OptionInfo("skipNextTurnScreen", &skipNextTurnScreen, false, "STR_SKIPNEXTTURNSCREEN", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("noAlienPanicMessages", &noAlienPanicMessages, false, "STR_NOALIENPANICMESSAGES", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("alienBleeding", &alienBleeding, false, "STR_ALIENBLEEDING", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("skipOutOfTime", &skipOutOfTime, false, "STR_SKIPOUTOFTIME", "STR_BATTLESCAPE"));
 
 	// controls
 	_info.push_back(OptionInfo("keyOk", &keyOk, SDLK_RETURN, "STR_OK", "STR_GENERAL"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -33,7 +33,7 @@ OPT SDLKey keyGeoLeft, keyGeoRight, keyGeoUp, keyGeoDown, keyGeoZoomIn, keyGeoZo
 OPT ScrollType battleEdgeScroll;
 OPT PathPreview battleNewPreviewPath;
 OPT int battleScrollSpeed, battleDragScrollButton, battleFireSpeed, battleXcomSpeed, battleAlienSpeed, battleExplosionHeight, battlescapeScale;
-OPT bool traceAI, sneakyAI, battleInstantGrenade, battleNotifyDeath, battleTooltips, battleHairBleach, battleAutoEnd,
+OPT bool traceAI, sneakyAI, battleInstantGrenade, battleNotifyDeath, battleTooltips, battleHairBleach, battleAutoEnd, skipOutOfTime,
 	strafe, forceFire, showMoreStatsInInventoryView, allowPsionicCapture, skipNextTurnScreen, disableAutoEquip, battleDragScrollInvert,
 	battleUFOExtenderAccuracy, battleConfirmFireMode, battleSmoothCamera, noAlienPanicMessages, alienBleeding;
 OPT SDLKey keyBattleLeft, keyBattleRight, keyBattleUp, keyBattleDown, keyBattleLevelUp, keyBattleLevelDown, keyBattleCenterUnit, keyBattlePrevUnit, keyBattleNextUnit, keyBattleDeselectUnit,

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1765,7 +1765,7 @@ void BattleUnit::allowReselect()
  */
 bool BattleUnit::reselectAllowed() const
 {
-	return !_dontReselect;
+	return !_dontReselect && (!Options::skipOutOfTime || _tu != 0);
 }
 
 /**


### PR DESCRIPTION
When clicking the "don't reselect unit" button, the player is generally finalizing their actions. It makes no sense to have to cycle through units who have zero time units and so cannot be given any further orders. This is especially frustrating when a large number of units have panicked.

This change adds an option to automatically skip over units with 0TU (it does not exclude skipped units from reselection through the "select next unit" button though)