### PR TITLE
Fix a scenario where mouse could not leave the window after switching from fullscreen to a windowed mode.

### DIFF
--- a/src/Menu/OptionsBaseState.cpp
+++ b/src/Menu/OptionsBaseState.cpp
@@ -203,8 +203,8 @@ void OptionsBaseState::btnOkClick(Action *)
 		Options::mapResources();
 	}
 	_game->loadLanguages();
-	SDL_WM_GrabInput(Options::captureMouse);
 	_game->getScreen()->resetDisplay();
+	SDL_WM_GrabInput(Options::captureMouse);
 	_game->setVolume(Options::soundVolume, Options::musicVolume, Options::uiVolume);
 	if (Options::reload && _origin == OPT_MENU)
 	{


### PR DESCRIPTION
When using `SDLcompat-1.2.68` the "Grab Mouse" option was not honored after switching from fullscreen to a windowed mode.

This PR should fix that behavior, by setting that option **after** the display reset.
